### PR TITLE
feat(migrate-legalhold-database-to-support-qualified-ids) Migrate Database to support QualifiedId  #WPB-11298

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wire.bots</groupId>
     <artifactId>hold</artifactId>
-    <version>1.0.7</version>
+    <version>1.1.0</version>
 
     <name>Legal Hold</name>
     <description>Legal Hold Service For Wire</description>
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <dropwizard.version>2.1.2</dropwizard.version>
+        <dropwizard.version>2.1.12</dropwizard.version>
         <openhtml.version>1.0.10</openhtml.version>
         <prometheus.version>0.16.0</prometheus.version>
     </properties>

--- a/src/main/java/com/wire/bots/hold/DAO/AccessResultSetMapper.java
+++ b/src/main/java/com/wire/bots/hold/DAO/AccessResultSetMapper.java
@@ -1,6 +1,7 @@
 package com.wire.bots.hold.DAO;
 
 import com.wire.bots.hold.model.database.LHAccess;
+import com.wire.xenon.backend.models.QualifiedId;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
@@ -13,7 +14,9 @@ public class AccessResultSetMapper implements ColumnMapper<LHAccess> {
     public LHAccess map(ResultSet rs, int columnNumber, StatementContext ctx) throws SQLException {
         LHAccess LHAccess = new LHAccess();
         LHAccess.last = (UUID) rs.getObject("last");
-        LHAccess.userId = (UUID) rs.getObject("userId");
+        UUID userId = (UUID) rs.getObject("userId");
+        String userDomain = rs.getString("userDomain");
+        LHAccess.userId = new QualifiedId(userId, userDomain);
         LHAccess.clientId = rs.getString("clientId");
         LHAccess.token = rs.getString("token");
         LHAccess.cookie = rs.getString("cookie");

--- a/src/main/java/com/wire/bots/hold/DAO/EventsDAO.java
+++ b/src/main/java/com/wire/bots/hold/DAO/EventsDAO.java
@@ -14,12 +14,14 @@ import java.util.List;
 import java.util.UUID;
 
 public interface EventsDAO {
-    @SqlUpdate("INSERT INTO Events (eventId, conversationId, userId, type, payload, time) " +
-            "VALUES (:eventId, :conversationId, :userId, :type, to_jsonb(:payload)::json, CURRENT_TIMESTAMP) " +
+    @SqlUpdate("INSERT INTO Events (eventId, conversationId, conversationDomain, userId, userDomain, type, payload, time) " +
+            "VALUES (:eventId, :conversationId, :conversationDomain, :userId, :userDomain, :type, to_jsonb(:payload)::json, CURRENT_TIMESTAMP) " +
             "ON CONFLICT (eventId) DO NOTHING")
     int insert(@Bind("eventId") UUID eventId,
                @Bind("conversationId") UUID conversationId,
+               @Bind("conversationDomain") String conversationDomain,
                @Bind("userId") UUID userId,
+               @Bind("userDomain") String userDomain,
                @Bind("type") String type,
                @Bind("payload") String payload);
 
@@ -27,7 +29,7 @@ public interface EventsDAO {
     @RegisterColumnMapper(EventsResultSetMapper.class)
     Event get(@Bind("eventId") UUID eventId);
 
-    @SqlQuery("SELECT * FROM Events WHERE conversationId = :conversationId AND (conversationDomain is NULL OR conversationDomain = :conversationDomain) ORDER BY time DESC")
+    @SqlQuery("SELECT * FROM Events WHERE conversationId = :conversationId AND (conversationDomain IS NULL OR conversationDomain = :conversationDomain) ORDER BY time DESC")
     @RegisterColumnMapper(EventsResultSetMapper.class)
     List<Event> listAllDefaultDomain(@Bind("conversationId") UUID conversationId,
         @Bind("conversationDomain") String conversationDomain);
@@ -37,7 +39,7 @@ public interface EventsDAO {
     List<Event> listAll(@Bind("conversationId") UUID conversationId,
         @Bind("conversationDomain") String conversationDomain);
 
-    @SqlQuery("SELECT * FROM Events WHERE conversationId = :conversationId AND (conversationDomain is NULL OR conversationDomain = :conversationDomain) ORDER BY time ASC")
+    @SqlQuery("SELECT * FROM Events WHERE conversationId = :conversationId AND (conversationDomain IS NULL OR conversationDomain = :conversationDomain) ORDER BY time ASC")
     @RegisterColumnMapper(EventsResultSetMapper.class)
     List<Event> listAllDefaultDomainAsc(@Bind("conversationId") UUID conversationId,
         @Bind("conversationDomain") String conversationDomain);

--- a/src/main/java/com/wire/bots/hold/DAO/EventsDAO.java
+++ b/src/main/java/com/wire/bots/hold/DAO/EventsDAO.java
@@ -27,13 +27,25 @@ public interface EventsDAO {
     @RegisterColumnMapper(EventsResultSetMapper.class)
     Event get(@Bind("eventId") UUID eventId);
 
-    @SqlQuery("SELECT * FROM Events WHERE conversationId = :conversationId ORDER BY time DESC")
+    @SqlQuery("SELECT * FROM Events WHERE conversationId = :conversationId AND (conversationDomain is NULL OR conversationDomain = :conversationDomain) ORDER BY time DESC")
     @RegisterColumnMapper(EventsResultSetMapper.class)
-    List<Event> listAll(@Bind("conversationId") UUID conversationId);
+    List<Event> listAllDefaultDomain(@Bind("conversationId") UUID conversationId,
+        @Bind("conversationDomain") String conversationDomain);
 
-    @SqlQuery("SELECT * FROM Events WHERE conversationId = :conversationId ORDER BY time ASC")
+    @SqlQuery("SELECT * FROM Events WHERE conversationId = :conversationId AND conversationDomain = :conversationDomain ORDER BY time DESC")
     @RegisterColumnMapper(EventsResultSetMapper.class)
-    List<Event> listAllAsc(@Bind("conversationId") UUID conversationId);
+    List<Event> listAll(@Bind("conversationId") UUID conversationId,
+        @Bind("conversationDomain") String conversationDomain);
+
+    @SqlQuery("SELECT * FROM Events WHERE conversationId = :conversationId AND (conversationDomain is NULL OR conversationDomain = :conversationDomain) ORDER BY time ASC")
+    @RegisterColumnMapper(EventsResultSetMapper.class)
+    List<Event> listAllDefaultDomainAsc(@Bind("conversationId") UUID conversationId,
+        @Bind("conversationDomain") String conversationDomain);
+
+    @SqlQuery("SELECT * FROM Events WHERE conversationId = :conversationId AND conversationDomain = :conversationDomain ORDER BY time ASC")
+    @RegisterColumnMapper(EventsResultSetMapper.class)
+    List<Event> listAllAsc(@Bind("conversationId") UUID conversationId,
+        @Bind("conversationDomain") String conversationDomain);
 
     @SqlQuery("SELECT DISTINCT conversationId, MAX(time) AS time " +
             "FROM Events " +

--- a/src/main/java/com/wire/bots/hold/DAO/EventsResultSetMapper.java
+++ b/src/main/java/com/wire/bots/hold/DAO/EventsResultSetMapper.java
@@ -22,7 +22,9 @@ public class EventsResultSetMapper implements ColumnMapper<Event> {
         Event event = new Event();
         event.eventId = (UUID) rs.getObject("eventId");
         event.conversationId = getUuid(rs, "conversationId");
+        event.conversationDomain = rs.getString("conversationDomain");
         event.userId = getUuid(rs, "userId");
+        event.userDomain = rs.getString("userDomain");
         event.time = rs.getString("time");
         event.type = rs.getString("type");
         event.payload = getPayload(rs);

--- a/src/main/java/com/wire/bots/hold/HoldMessageResource.java
+++ b/src/main/java/com/wire/bots/hold/HoldMessageResource.java
@@ -6,6 +6,7 @@ import com.wire.xenon.MessageHandlerBase;
 import com.wire.xenon.MessageResourceBase;
 import com.wire.xenon.WireClient;
 import com.wire.xenon.backend.models.Payload;
+import com.wire.xenon.backend.models.QualifiedId;
 import com.wire.xenon.exceptions.MissingStateException;
 import com.wire.xenon.tools.Logger;
 
@@ -19,12 +20,11 @@ public class HoldMessageResource extends MessageResourceBase {
         this.repo = repo;
     }
 
-    protected WireClient getWireClient(UUID userId, Payload payload) throws CryptoException {
+    protected WireClient getWireClient(QualifiedId userId, Payload payload) throws CryptoException {
         return repo.getClient(userId, payload.data.recipient, payload.conversation);
     }
 
-    public boolean onNewMessage(UUID userId, UUID id, Payload payload) {
-
+    public boolean onNewMessage(QualifiedId userId, UUID id, Payload payload) {
         try (WireClient client = getWireClient(userId, payload)) {
             handleMessage(id, payload, client);
         } catch (CryptoException | MissingStateException e) {

--- a/src/main/java/com/wire/bots/hold/Service.java
+++ b/src/main/java/com/wire/bots/hold/Service.java
@@ -25,6 +25,7 @@ import com.wire.bots.hold.DAO.EventsDAO;
 import com.wire.bots.hold.DAO.MetadataDAO;
 import com.wire.bots.hold.filters.ServiceAuthenticationFilter;
 import com.wire.bots.hold.healthchecks.SanityCheck;
+import com.wire.bots.hold.monitoring.ApiVersionResource;
 import com.wire.bots.hold.monitoring.RequestMdcFactoryFilter;
 import com.wire.bots.hold.monitoring.StatusResource;
 import com.wire.bots.hold.resource.v0.audit.*;
@@ -126,6 +127,7 @@ public class Service extends Application<Config> {
 
         // Monitoring resources
         addResource(new StatusResource());
+        addResource(new ApiVersionResource());
         addResource(new RequestMdcFactoryFilter());
 
         // Used by Wire Server

--- a/src/main/java/com/wire/bots/hold/healthchecks/SanityCheck.java
+++ b/src/main/java/com/wire/bots/hold/healthchecks/SanityCheck.java
@@ -5,7 +5,6 @@ import com.wire.bots.hold.DAO.AccessDAO;
 import com.wire.bots.hold.model.database.LHAccess;
 import com.wire.bots.hold.utils.Cache;
 import com.wire.helium.API;
-import com.wire.xenon.backend.models.QualifiedId;
 import com.wire.xenon.tools.Logger;
 
 import javax.ws.rs.client.Client;
@@ -37,10 +36,11 @@ public class SanityCheck extends HealthCheck {
             while (!accessList.isEmpty()) {
                 Logger.info("SanityCheck: checking %d devices, created: %s", accessList.size(), created);
                 for (LHAccess access : accessList) {
-                    // TODO(WPB-11287): Use user domain if exists, otherwise default
-                    // TODO: String domain = (access.domain != null) ? access.domain : Cache.DEFAULT_DOMAIN;
+                    if (access.userId.domain == null) {
+                        access.userId.domain = Cache.getFallbackDomain();
+                    }
                     boolean hasDevice = api.hasDevice(
-                        new QualifiedId(access.userId, Cache.getFallbackDomain()), // TODO(WPB-11287): Change null to default domain
+                        access.userId,
                         access.clientId
                     );
 

--- a/src/main/java/com/wire/bots/hold/model/database/Event.java
+++ b/src/main/java/com/wire/bots/hold/model/database/Event.java
@@ -5,7 +5,9 @@ import java.util.UUID;
 public class Event {
     public UUID eventId;
     public UUID conversationId;
+    public String conversationDomain; // Keeping values split instead of using QualifiedId because of HTML templating
     public UUID userId;
+    public String userDomain; // Keeping values split instead of using QualifiedId because of HTML templating
     public String type;
     public String payload;
     public String time;

--- a/src/main/java/com/wire/bots/hold/model/database/LHAccess.java
+++ b/src/main/java/com/wire/bots/hold/model/database/LHAccess.java
@@ -1,10 +1,12 @@
 package com.wire.bots.hold.model.database;
 
+import com.wire.xenon.backend.models.QualifiedId;
+
 import java.util.UUID;
 
 public class LHAccess {
     public UUID last;
-    public UUID userId;
+    public QualifiedId userId;
     public String clientId;
     public String token;
     public String cookie;

--- a/src/main/java/com/wire/bots/hold/monitoring/StatusResource.java
+++ b/src/main/java/com/wire/bots/hold/monitoring/StatusResource.java
@@ -28,7 +28,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 @Api
-@Path("/status")
+@Path("/{parameter: status|v1/status}")
 @Produces(MediaType.TEXT_PLAIN)
 public class StatusResource {
     @GET

--- a/src/main/java/com/wire/bots/hold/resource/v0/audit/ConversationResource.java
+++ b/src/main/java/com/wire/bots/hold/resource/v0/audit/ConversationResource.java
@@ -65,8 +65,9 @@ public class ConversationResource {
     public Response list(@ApiParam @PathParam("conversationId") UUID conversationId,
                          @ApiParam @QueryParam("html") boolean isHtml) {
         try {
-            //TODO Get DEFAULT_DOMAIN, then fetch events with domain = null and domain = DEFAULT_DOMAIN
-            List<Event> events = eventsDAO.listAllDefaultDomainAsc(conversationId);
+            // TODO: When the parameters of this resource changes to accept a QualifiedId, then we will need
+            // to verify based on the domain which DAO query to call
+            List<Event> events = eventsDAO.listAllDefaultDomainAsc(conversationId, Cache.getFallbackDomain());
 
             testAPI();
 
@@ -299,7 +300,7 @@ public class ConversationResource {
 
     private String formatConversation(Conversation conversation) {
         StringBuilder sb = new StringBuilder();
-        QualifiedId creatorId = new QualifiedId(conversation.creator, null); // TODO(WPB-11287): Change null to default domain
+        QualifiedId creatorId = new QualifiedId(conversation.creator, Cache.getFallbackDomain());
         sb.append(String.format("**%s** created conversation **%s** with: \n",
                 getUserName(creatorId),
                 conversation.name));

--- a/src/main/java/com/wire/bots/hold/resource/v0/audit/ConversationResource.java
+++ b/src/main/java/com/wire/bots/hold/resource/v0/audit/ConversationResource.java
@@ -65,9 +65,8 @@ public class ConversationResource {
     public Response list(@ApiParam @PathParam("conversationId") UUID conversationId,
                          @ApiParam @QueryParam("html") boolean isHtml) {
         try {
-            List<Event> events = eventsDAO.listAllAsc(conversationId);
-
-            // TODO(WPB-11287) Verify default domain
+            //TODO Get DEFAULT_DOMAIN, then fetch events with domain = null and domain = DEFAULT_DOMAIN
+            List<Event> events = eventsDAO.listAllDefaultDomainAsc(conversationId);
 
             testAPI();
 

--- a/src/main/java/com/wire/bots/hold/resource/v0/audit/DevicesResource.java
+++ b/src/main/java/com/wire/bots/hold/resource/v0/audit/DevicesResource.java
@@ -6,8 +6,9 @@ import com.github.mustachejava.MustacheFactory;
 import com.wire.bots.hold.DAO.AccessDAO;
 import com.wire.bots.hold.filters.ServiceAuthorization;
 import com.wire.bots.hold.model.database.LHAccess;
+import com.wire.bots.hold.utils.CryptoDatabaseFactory;
+import com.wire.xenon.backend.models.QualifiedId;
 import com.wire.xenon.crypto.Crypto;
-import com.wire.xenon.factories.CryptoFactory;
 import com.wire.xenon.tools.Logger;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -32,10 +33,10 @@ import static com.wire.bots.hold.utils.Tools.hexify;
 @Produces(MediaType.TEXT_HTML)
 public class DevicesResource {
     private final static MustacheFactory mf = new DefaultMustacheFactory();
-    private final CryptoFactory cryptoFactory;
+    private final CryptoDatabaseFactory cryptoFactory;
     private final AccessDAO accessDAO;
 
-    public DevicesResource(AccessDAO accessDAO, CryptoFactory cryptoFactory) {
+    public DevicesResource(AccessDAO accessDAO, CryptoDatabaseFactory cryptoFactory) {
         this.cryptoFactory = cryptoFactory;
         this.accessDAO = accessDAO;
     }
@@ -95,7 +96,7 @@ public class DevicesResource {
 
     static class Legal {
         UUID last;
-        UUID userId;
+        QualifiedId userId;
         String clientId;
         String fingerprint;
         String updated;

--- a/src/main/java/com/wire/bots/hold/resource/v0/audit/EventsResource.java
+++ b/src/main/java/com/wire/bots/hold/resource/v0/audit/EventsResource.java
@@ -40,8 +40,9 @@ public class EventsResource {
             @ApiResponse(code = 200, message = "Wire events")})
     public Response list(@ApiParam @PathParam("conversationId") UUID conversationId) {
         try {
+            //TODO Get DEFAULT_DOMAIN, then fetch events with domain = null and domain = DEFAULT_DOMAIN
             Model model = new Model();
-            model.events = eventsDAO.listAll(conversationId);
+            model.events = eventsDAO.listAllDefaultDomain(conversationId);
             String html = execute(model);
 
             return Response.

--- a/src/main/java/com/wire/bots/hold/resource/v0/audit/EventsResource.java
+++ b/src/main/java/com/wire/bots/hold/resource/v0/audit/EventsResource.java
@@ -6,6 +6,7 @@ import com.github.mustachejava.MustacheFactory;
 import com.wire.bots.hold.DAO.EventsDAO;
 import com.wire.bots.hold.filters.ServiceAuthorization;
 import com.wire.bots.hold.model.database.Event;
+import com.wire.bots.hold.utils.Cache;
 import com.wire.xenon.tools.Logger;
 import io.swagger.annotations.*;
 
@@ -40,18 +41,19 @@ public class EventsResource {
             @ApiResponse(code = 200, message = "Wire events")})
     public Response list(@ApiParam @PathParam("conversationId") UUID conversationId) {
         try {
-            //TODO Get DEFAULT_DOMAIN, then fetch events with domain = null and domain = DEFAULT_DOMAIN
+            // TODO: When the parameters of this resource changes to accept a QualifiedId, then we will need
+            // to verify based on the domain which DAO query to call
             Model model = new Model();
-            model.events = eventsDAO.listAllDefaultDomain(conversationId);
+            model.events = eventsDAO.listAllDefaultDomain(conversationId, Cache.getFallbackDomain());
             String html = execute(model);
 
             return Response.
                     ok(html, MediaType.TEXT_HTML).
                     build();
-        } catch (Exception e) {
-            Logger.exception("EventsResource.list: %s", e, e.getMessage());
+        } catch (Exception exception) {
+            Logger.exception(exception, "EventsResource.list: %s", exception.getMessage());
             return Response
-                    .ok(e.getMessage())
+                    .ok(exception.getMessage())
                     .status(500)
                     .build();
         }

--- a/src/main/java/com/wire/bots/hold/resource/v0/backend/ConfirmResourceV0.java
+++ b/src/main/java/com/wire/bots/hold/resource/v0/backend/ConfirmResourceV0.java
@@ -35,7 +35,7 @@ public class ConfirmResourceV0 {
     public Response confirm(@ApiParam @Valid @NotNull ConfirmPayloadV0 payload) {
         try {
             deviceManagementService.confirmDevice(
-                new QualifiedId(payload.userId, null), //TODO Probably a good place to put the DEFAULT_DOMAIN
+                new QualifiedId(payload.userId, null),
                 payload.teamId,
                 payload.clientId,
                 payload.refreshToken

--- a/src/main/java/com/wire/bots/hold/resource/v0/backend/InitiateResourceV0.java
+++ b/src/main/java/com/wire/bots/hold/resource/v0/backend/InitiateResourceV0.java
@@ -38,7 +38,7 @@ public class InitiateResourceV0 {
         try {
             final InitializedDeviceDTO initializedDeviceDTO =
                 deviceManagementService.initiateLegalHoldDevice(
-                    new QualifiedId(init.userId, null), //TODO Probably a good place to put the DEFAULT_DOMAIN
+                    new QualifiedId(init.userId, null),
                     init.teamId
                 );
 

--- a/src/main/java/com/wire/bots/hold/resource/v0/backend/RemoveResourceV0.java
+++ b/src/main/java/com/wire/bots/hold/resource/v0/backend/RemoveResourceV0.java
@@ -34,7 +34,7 @@ public class RemoveResourceV0 {
     public Response remove(@ApiParam @Valid InitPayloadV0 payload) {
         try {
             deviceManagementService.removeDevice(
-                new QualifiedId(payload.userId, null), //TODO Probably a good place to put the DEFAULT_DOMAIN
+                new QualifiedId(payload.userId, null),
                 payload.teamId
             );
 

--- a/src/main/java/com/wire/bots/hold/service/DeviceManagementService.java
+++ b/src/main/java/com/wire/bots/hold/service/DeviceManagementService.java
@@ -67,6 +67,7 @@ public class DeviceManagementService {
      */
     public void confirmDevice(QualifiedId userId, UUID teamId, String clientId, String refreshToken) {
         int insert = accessDAO.insert(userId.id,
+            userId.domain,
             clientId,
             refreshToken);
 
@@ -95,7 +96,7 @@ public class DeviceManagementService {
         try (Crypto crypto = cf.create(userId)) {
             crypto.purge();
 
-            int removeAccess = accessDAO.disable(userId.id);
+            int removeAccess = accessDAO.disable(userId.id, userId.domain);
 
             Logger.info(
                 "RemoveResource: team: %s, user: %s, removed: %s",

--- a/src/main/java/com/wire/bots/hold/utils/Collector.java
+++ b/src/main/java/com/wire/bots/hold/utils/Collector.java
@@ -68,7 +68,7 @@ public class Collector {
 
     private Sender sender(User user, Message message) {
         Sender sender = new Sender();
-        sender.senderId = user.id;
+        sender.senderId = user.id.toString();
         sender.name = user.name;
         sender.accent = toColor(user.accent);
         sender.avatar = getAvatar(user);
@@ -79,7 +79,7 @@ public class Collector {
     private Sender system(Message message, String type) {
         Sender sender = new Sender();
         sender.system = "system";
-        sender.senderId = new QualifiedId(UUID.randomUUID(), null); // TODO(WPB-11287): Change null to default domain
+        sender.senderId = "system";
         sender.avatar = systemIcon(type);
         sender.messages.add(message);
         return sender;
@@ -213,7 +213,7 @@ public class Collector {
     }
 
     public static class Sender {
-        QualifiedId senderId;
+        String senderId;
         String avatar;
         String name;
         String accent;

--- a/src/main/java/com/wire/bots/hold/utils/HoldClientRepo.java
+++ b/src/main/java/com/wire/bots/hold/utils/HoldClientRepo.java
@@ -7,7 +7,6 @@ import com.wire.helium.API;
 import com.wire.xenon.WireClient;
 import com.wire.xenon.backend.models.QualifiedId;
 import com.wire.xenon.crypto.Crypto;
-import com.wire.xenon.factories.CryptoFactory;
 import org.jdbi.v3.core.Jdbi;
 
 import javax.ws.rs.client.Client;
@@ -16,10 +15,10 @@ import java.util.UUID;
 public class HoldClientRepo {
 
     private final Jdbi jdbi;
-    private final CryptoFactory cf;
+    private final CryptoDatabaseFactory cf;
     private final Client httpClient;
 
-    public HoldClientRepo(Jdbi jdbi, CryptoFactory cf, Client httpClient) {
+    public HoldClientRepo(Jdbi jdbi, CryptoDatabaseFactory cf, Client httpClient) {
         this.jdbi = jdbi;
         this.cf = cf;
         this.httpClient = httpClient;

--- a/src/main/java/com/wire/bots/hold/utils/HoldClientRepo.java
+++ b/src/main/java/com/wire/bots/hold/utils/HoldClientRepo.java
@@ -10,7 +10,6 @@ import com.wire.xenon.crypto.Crypto;
 import org.jdbi.v3.core.Jdbi;
 
 import javax.ws.rs.client.Client;
-import java.util.UUID;
 
 public class HoldClientRepo {
 
@@ -24,9 +23,9 @@ public class HoldClientRepo {
         this.httpClient = httpClient;
     }
 
-    public WireClient getClient(UUID userId, String deviceId, QualifiedId conversationId) throws CryptoException {
+    public WireClient getClient(QualifiedId userId, String deviceId, QualifiedId conversationId) throws CryptoException {
         Crypto crypto = cf.create(userId);
-        final LHAccess single = jdbi.onDemand(AccessDAO.class).get(userId);
+        final LHAccess single = jdbi.onDemand(AccessDAO.class).get(userId.id, userId.domain);
         final API api = new API(httpClient, conversationId, single.token);
         return new HoldWireClient(userId, deviceId, conversationId, crypto, api);
     }

--- a/src/main/java/com/wire/bots/hold/utils/HoldWireClient.java
+++ b/src/main/java/com/wire/bots/hold/utils/HoldWireClient.java
@@ -15,20 +15,37 @@ import java.util.UUID;
 
 public class HoldWireClient extends WireClientBase implements WireClient {
 
-    private final UUID userId;
-    private final QualifiedId convId;
+    private final User user;
+    private final QualifiedId conversationId;
     private final String deviceId;
 
-    HoldWireClient(UUID userId, String deviceId, QualifiedId convId, Crypto crypto, API api) {
+    HoldWireClient(QualifiedId userId, String deviceId, QualifiedId convId, Crypto crypto, API api) {
         super(api, crypto, null);
-        this.userId = userId;
-        this.convId = convId;
+
+        User user =  new User();
+        user.id = userId;
+        this.user = user;
+
+        this.conversationId = convId;
         this.deviceId = deviceId;
     }
 
+    /**
+     * <p>
+     *     This method used to return the direct UUID (userId) saved in this Class, but userId is now changed to User.
+     *     User contains the new QualifiedId, consisting of ID and Domain.
+     * </p>
+     * <p>
+     *     As this method is still used in Xenon, this method needs to return something valid.
+     * </p>
+     *
+     * @return UUID from User Qualified ID
+     * @Deprecated Use getSelf() instead
+     */
+    @Deprecated
     @Override
     public UUID getId() {
-        return userId;
+        return user.id.id;
     }
 
     @Override
@@ -38,14 +55,26 @@ public class HoldWireClient extends WireClientBase implements WireClient {
 
     @Override
     public QualifiedId getConversationId() {
-        return convId;
+        return conversationId;
     }
 
     ////////////////////////////////////////////////////////////
 
+    /**
+     * <p>
+     *     This method returns a User object with minimal data (only containing its QualifiedId) and deprecates the
+     *     `getId()` method in this class, as previously by chance both User and Bot/Service only had one type of ID.
+     * </p>
+     * <p>
+     *     Now, Users contain a combination of UUID(id) and String(domain) to compose the User ID, whilst Bot/Service
+     *     still uses the same UUID(id) type.
+     * </p>
+     *
+     * @return User with minimal data.
+     */
     @Override
     public User getSelf() {
-        return null;
+        return user;
     }
 
     @Override
@@ -72,5 +101,4 @@ public class HoldWireClient extends WireClientBase implements WireClient {
     public AssetKey uploadAsset(IAsset asset) {
         return null;
     }
-
 }

--- a/src/main/resources/db/migration/V108__add_domain_column_in_access_events.sql
+++ b/src/main/resources/db/migration/V108__add_domain_column_in_access_events.sql
@@ -1,6 +1,9 @@
 ALTER TABLE Access
 ADD COLUMN userDomain VARCHAR(255) DEFAULT null;
 
+-- Dropping the PRIMARY KEY and adding a UNIQUE constraint with both Id and Domain,
+-- because Postgresql doesn't like a nullable fields being PRIMARY KEY.
+-- (previous tentative: PRIMARY KEY (userId, userDomain)
 ALTER TABLE Access
 DROP CONSTRAINT IF EXISTS access_pkey;
 

--- a/src/main/resources/db/migration/V108__add_domain_column_in_access_events.sql
+++ b/src/main/resources/db/migration/V108__add_domain_column_in_access_events.sql
@@ -1,0 +1,16 @@
+ALTER TABLE Access
+ADD COLUMN userDomain VARCHAR(255) DEFAULT null;
+
+ALTER TABLE Access
+DROP CONSTRAINT IF EXISTS access_pkey;
+
+ALTER TABLE Access ADD CONSTRAINT access_user_id_user_domain_key UNIQUE (userId, userDomain);
+
+ALTER TABLE Events
+ADD COLUMN userDomain VARCHAR(255) DEFAULT null;
+
+ALTER TABLE Events
+ADD COLUMN conversationDomain VARCHAR(255) DEFAULT null;
+
+DROP INDEX conversation_id_idx;
+CREATE INDEX events_conversation_id_conversation_domain_idx ON Events (conversationId, conversationDomain);

--- a/src/test/java/com/wire/bots/hold/ConfirmRemoveResourceV1Test.java
+++ b/src/test/java/com/wire/bots/hold/ConfirmRemoveResourceV1Test.java
@@ -91,7 +91,7 @@ public class ConfirmRemoveResourceV1Test {
         assert confirmSecondResponse.getStatus() == HttpStatus.SC_OK;
 
         // Confirm the same device is possible and the latest refresh_token should be persisted
-        final LHAccess lhAccess = accessDAO.get(userId.id);
+        final LHAccess lhAccess = accessDAO.get(userId.id, userId.domain);
         assert lhAccess != null;
         assert lhAccess.cookie.equals(updatedRefreshToken);
         assert !lhAccess.created.equals(lhAccess.updated);
@@ -121,7 +121,7 @@ public class ConfirmRemoveResourceV1Test {
             .post(Entity.entity(confirmPayloadV1, MediaType.APPLICATION_JSON));
     }
 
-    private Response postRemoveV1(InitPayloadV1 initPayloadV1){
+    private Response postRemoveV1(InitPayloadV1 initPayloadV1) {
         return client.target("http://localhost:" + SUPPORT.getLocalPort())
             .path("v1")
             .path("remove")

--- a/src/test/java/com/wire/bots/hold/DatabaseTest.java
+++ b/src/test/java/com/wire/bots/hold/DatabaseTest.java
@@ -52,20 +52,20 @@ public class DatabaseTest {
         final String type = "conversation.otr-message-add.new-text";
         final UUID eventId = UUID.randomUUID();
         final UUID messageId = UUID.randomUUID();
-        final QualifiedId convId = new QualifiedId(UUID.randomUUID(), null);
+        final QualifiedId convId = new QualifiedId(UUID.randomUUID(), "dummy_domain");
         final String clientId = UUID.randomUUID().toString();
-        final QualifiedId userId  = new QualifiedId(UUID.randomUUID(), null);
+        final QualifiedId userId  = new QualifiedId(UUID.randomUUID(), "dummy_domain");
         final String time = new Date().toString();
         final TextMessage textMessage = new TextMessage(eventId, messageId, convId, clientId, userId, time);
-        textMessage.addMention(new QualifiedId(UUID.randomUUID(), null), 0, 5);
+        textMessage.addMention(new QualifiedId(UUID.randomUUID(), "dummy_domain"), 0, 5);
         textMessage.setText("Some text");
 
         String payload = mapper.writeValueAsString(textMessage);
 
-        int insert = eventsDAO.insert(eventId, convId.id, userId.id, type, payload);
+        int insert = eventsDAO.insert(eventId, convId.id, convId.domain, userId.id, userId.domain, type, payload);
         assert insert == 1;
 
-        insert = eventsDAO.insert(UUID.randomUUID(), convId.id, userId.id, type, payload);
+        insert = eventsDAO.insert(UUID.randomUUID(), convId.id, convId.domain, userId.id, userId.domain, type, payload);
         assert insert == 1;
 
         final Event event = eventsDAO.get(eventId);
@@ -74,7 +74,7 @@ public class DatabaseTest {
 
         assert textMessage.getMessageId().equals(message.getMessageId());
 
-        List<Event> events = eventsDAO.listAllDefaultDomain(convId.id);
+        List<Event> events = eventsDAO.listAllDefaultDomain(convId.id, convId.domain);
         assert events.size() == 2;
     }
 
@@ -105,17 +105,17 @@ public class DatabaseTest {
         final String token = "token";
 
         final int insert = accessDAO.insert(userId.id, userId.domain, clientId, cookie);
-        accessDAO.updateLast(userId, last);
-        accessDAO.update(userId, token, cookie2);
+        accessDAO.updateLast(userId.id, userId.domain, last);
+        accessDAO.update(userId.id, userId.domain, token, cookie2);
 
-        final LHAccess lhAccess = accessDAO.get(userId);
+        final LHAccess lhAccess = accessDAO.get(userId.id, userId.domain);
         assert lhAccess != null;
         assert lhAccess.userId.equals(userId);
 
-        accessDAO.disable(userId);
+        accessDAO.disable(userId.id, userId.domain);
 
-        final int insert2 = accessDAO.insert(userId, clientId, cookie);
-        final LHAccess lhAccess2 = accessDAO.get(userId);
+        final int insert2 = accessDAO.insert(userId.id, userId.domain, clientId, cookie);
+        final LHAccess lhAccess2 = accessDAO.get(userId.id, userId.domain);
         assert lhAccess2 != null;
         assert lhAccess2.created.equals(lhAccess.created);
     }

--- a/src/test/java/com/wire/bots/hold/DatabaseTest.java
+++ b/src/test/java/com/wire/bots/hold/DatabaseTest.java
@@ -74,7 +74,7 @@ public class DatabaseTest {
 
         assert textMessage.getMessageId().equals(message.getMessageId());
 
-        List<Event> events = eventsDAO.listAll(convId.id);
+        List<Event> events = eventsDAO.listAllDefaultDomain(convId.id);
         assert events.size() == 2;
     }
 
@@ -97,14 +97,14 @@ public class DatabaseTest {
 
     @Test
     public void accessTests() {
-        final UUID userId = UUID.randomUUID();
+        final QualifiedId userId = new QualifiedId(UUID.randomUUID(), UUID.randomUUID().toString());
         final String clientId = UUID.randomUUID().toString();
         final String cookie = "cookie";
         final UUID last = UUID.randomUUID();
         final String cookie2 = "cookie2";
         final String token = "token";
 
-        final int insert = accessDAO.insert(userId, clientId, cookie);
+        final int insert = accessDAO.insert(userId.id, userId.domain, clientId, cookie);
         accessDAO.updateLast(userId, last);
         accessDAO.update(userId, token, cookie2);
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Current Database doesn't support qualified Ids

### Solutions

Migrate database to support qualified ids:
- 1 Field: [userId] -> 2 Fields: [userId, userDomain]
- 1 Field: [conversationId] -> 2 Fields: [conversationId, conversationDomain]

- Updated project to version `1.1.0`
- Updated Dropwizard to latest supported version for `2.x` -> `2.1.12`

Main points of changes were done in `AccessDAO` and `EventsDAO` for inserting and getting values, now both receiving and returning qualified ids for `User` and `Conversation`

`HoldWireClient` now receives a `QualifiedId userId` and now holds a `User` value in-memory and not just the `UUID` anymore.
   - `getId()` now returns User id from QualifiedId
   - `getSelf()` returns the `User` object and should be used from now on. (Specially from `MessageHandler`, can see changes from files)

`MessageHandler` is now persisting data with correct qualified Ids

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

- After project is built, can run from terminal: `mvn test` and all current `22` tests should pass.
- Manual tests were done as well, making real-usage with `Android`<>`Web` with a device on LegalHold and some other manual requests to:
   - `https://LEGALHOLD_URL/index.html`
   - `https://LEGALHOLD_URL/events/CONVERSATION_ID`
   - `https://LEGALHOLD_URL/conv/CONVERSATION_ID`

### Notes (Optional)

From the PDF generation, it is not showing the user profile picture, but we came to the conclusion that it was an old issue and will be creating a ticket to be verified later.

### Attachments (Optional)
![pdf_preview](https://github.com/user-attachments/assets/3ce96ad8-955b-4ffb-9261-14ce1677f116)

