### PR TITLE
feat(support-qualified-id-in-audit-apis) Support domain parameter in Audit APIs #WPB-11459

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <dropwizard.version>2.1.12</dropwizard.version>
+        <dropwizard.version>2.1.2</dropwizard.version>
         <openhtml.version>1.0.10</openhtml.version>
         <prometheus.version>0.16.0</prometheus.version>
     </properties>

--- a/src/main/java/com/wire/bots/hold/DAO/EventsDAO.java
+++ b/src/main/java/com/wire/bots/hold/DAO/EventsDAO.java
@@ -51,7 +51,7 @@ public interface EventsDAO {
 
     @SqlQuery("SELECT DISTINCT conversationId, conversationDomain, MAX(time) AS time " +
             "FROM Events " +
-            "GROUP BY conversationId " +
+            "GROUP BY conversationId, conversationDomain " +
             "ORDER BY MAX(time) DESC, conversationId " +
             "LIMIT 400")
     @RegisterColumnMapper(_EventsResultSetMapper.class)
@@ -67,6 +67,7 @@ public interface EventsDAO {
             Object conversationId = rs.getObject("conversationId");
             if (conversationId != null)
                 event.conversationId = (UUID) conversationId;
+            event.conversationDomain = rs.getString("conversationDomain");
             event.time = rs.getString("time");
 
             return event;

--- a/src/main/java/com/wire/bots/hold/DAO/EventsDAO.java
+++ b/src/main/java/com/wire/bots/hold/DAO/EventsDAO.java
@@ -49,7 +49,7 @@ public interface EventsDAO {
     List<Event> listAllAsc(@Bind("conversationId") UUID conversationId,
         @Bind("conversationDomain") String conversationDomain);
 
-    @SqlQuery("SELECT DISTINCT conversationId, MAX(time) AS time " +
+    @SqlQuery("SELECT DISTINCT conversationId, conversationDomain, MAX(time) AS time " +
             "FROM Events " +
             "GROUP BY conversationId " +
             "ORDER BY MAX(time) DESC, conversationId " +

--- a/src/main/java/com/wire/bots/hold/FallbackDomainFetcher.java
+++ b/src/main/java/com/wire/bots/hold/FallbackDomainFetcher.java
@@ -62,7 +62,7 @@ public class FallbackDomainFetcher implements Runnable {
             }
         } catch (HttpException exception) {
             Logger.exception(exception, "FallbackDomainFetcher.run, exception: %s", exception.getMessage());
-        } catch (ProcessingException pexception) {
+        } catch (ProcessingException exception) {
             Logger.info("FallbackDomainFetcher.run, ignoring test exceptions");
         }
     }

--- a/src/main/java/com/wire/bots/hold/model/EventModel.java
+++ b/src/main/java/com/wire/bots/hold/model/EventModel.java
@@ -1,0 +1,9 @@
+package com.wire.bots.hold.model;
+
+import com.wire.bots.hold.model.database.Event;
+
+import java.util.List;
+
+public class EventModel {
+    public List<Event> events;
+}

--- a/src/main/java/com/wire/bots/hold/resource/v0/audit/DevicesResource.java
+++ b/src/main/java/com/wire/bots/hold/resource/v0/audit/DevicesResource.java
@@ -1,12 +1,10 @@
 package com.wire.bots.hold.resource.v0.audit;
 
-import com.github.mustachejava.DefaultMustacheFactory;
-import com.github.mustachejava.Mustache;
-import com.github.mustachejava.MustacheFactory;
 import com.wire.bots.hold.DAO.AccessDAO;
 import com.wire.bots.hold.filters.ServiceAuthorization;
 import com.wire.bots.hold.model.database.LHAccess;
 import com.wire.bots.hold.utils.CryptoDatabaseFactory;
+import com.wire.bots.hold.utils.HtmlGenerator;
 import com.wire.xenon.backend.models.QualifiedId;
 import com.wire.xenon.crypto.Crypto;
 import com.wire.xenon.tools.Logger;
@@ -20,9 +18,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.UUID;
 
@@ -32,7 +27,6 @@ import static com.wire.bots.hold.utils.Tools.hexify;
 @Path("/devices.html")
 @Produces(MediaType.TEXT_HTML)
 public class DevicesResource {
-    private final static MustacheFactory mf = new DefaultMustacheFactory();
     private final CryptoDatabaseFactory cryptoFactory;
     private final AccessDAO accessDAO;
 
@@ -67,7 +61,7 @@ public class DevicesResource {
 
             Model model = new Model();
             model.legals = legals;
-            String html = execute(model);
+            String html = HtmlGenerator.execute(model, HtmlGenerator.TemplateType.DEVICES);
 
             return Response.
                     ok(html, MediaType.TEXT_HTML).
@@ -78,19 +72,6 @@ public class DevicesResource {
                     .ok(e.getMessage())
                     .status(500)
                     .build();
-        }
-    }
-
-    private Mustache compileTemplate() {
-        String path = "templates/devices.html";
-        return mf.compile(path);
-    }
-
-    private String execute(Object model) throws IOException {
-        Mustache mustache = compileTemplate();
-        try (StringWriter sw = new StringWriter()) {
-            mustache.execute(new PrintWriter(sw), model).flush();
-            return sw.toString();
         }
     }
 

--- a/src/main/java/com/wire/bots/hold/resource/v0/audit/EventsResource.java
+++ b/src/main/java/com/wire/bots/hold/resource/v0/audit/EventsResource.java
@@ -1,12 +1,10 @@
 package com.wire.bots.hold.resource.v0.audit;
 
-import com.github.mustachejava.DefaultMustacheFactory;
-import com.github.mustachejava.Mustache;
-import com.github.mustachejava.MustacheFactory;
 import com.wire.bots.hold.DAO.EventsDAO;
 import com.wire.bots.hold.filters.ServiceAuthorization;
-import com.wire.bots.hold.model.database.Event;
+import com.wire.bots.hold.model.EventModel;
 import com.wire.bots.hold.utils.Cache;
+import com.wire.bots.hold.utils.HtmlGenerator;
 import com.wire.xenon.tools.Logger;
 import io.swagger.annotations.*;
 
@@ -16,17 +14,12 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.List;
 import java.util.UUID;
 
 @Api
-@Path("/events/{conversationId}")
+@Path("/events/{conversationId}{noop: (/)?}{conversationDomain:([^/]+?)?}")
 @Produces(MediaType.TEXT_HTML)
 public class EventsResource {
-    private final static MustacheFactory mf = new DefaultMustacheFactory();
     private final EventsDAO eventsDAO;
 
     public EventsResource(EventsDAO eventsDAO) {
@@ -38,14 +31,22 @@ public class EventsResource {
     @ApiOperation(value = "List all Wire events for this conversation")
     @ApiResponses(value = {
             @ApiResponse(code = 500, message = "Something went wrong"),
-            @ApiResponse(code = 200, message = "Wire events")})
-    public Response list(@ApiParam @PathParam("conversationId") UUID conversationId) {
+            @ApiResponse(code = 200, message = "Wire events")}
+    )
+    public Response list(
+        @ApiParam @PathParam("conversationId") UUID conversationId,
+        @ApiParam @PathParam("conversationDomain") String conversationDomain
+    ) {
+        boolean isValidDomain = conversationDomain != null && !conversationDomain.isEmpty();
+
         try {
-            // TODO: When the parameters of this resource changes to accept a QualifiedId, then we will need
-            // to verify based on the domain which DAO query to call
-            Model model = new Model();
-            model.events = eventsDAO.listAllDefaultDomain(conversationId, Cache.getFallbackDomain());
-            String html = execute(model);
+            EventModel model = new EventModel();
+            if (isValidDomain && !conversationDomain.equals(Cache.getFallbackDomain())) {
+                model.events = eventsDAO.listAll(conversationId, conversationDomain);
+            } else {
+                model.events = eventsDAO.listAllDefaultDomain(conversationId, Cache.getFallbackDomain());
+            }
+            String html = HtmlGenerator.execute(model, HtmlGenerator.TemplateType.EVENTS);
 
             return Response.
                     ok(html, MediaType.TEXT_HTML).
@@ -57,22 +58,5 @@ public class EventsResource {
                     .status(500)
                     .build();
         }
-    }
-
-    private Mustache compileTemplate() {
-        String path = "templates/events.html";
-        return mf.compile(path);
-    }
-
-    private String execute(Object model) throws IOException {
-        Mustache mustache = compileTemplate();
-        try (StringWriter sw = new StringWriter()) {
-            mustache.execute(new PrintWriter(sw), model).flush();
-            return sw.toString();
-        }
-    }
-
-    static class Model {
-        List<Event> events;
     }
 }

--- a/src/main/java/com/wire/bots/hold/resource/v0/audit/IndexResource.java
+++ b/src/main/java/com/wire/bots/hold/resource/v0/audit/IndexResource.java
@@ -1,11 +1,9 @@
 package com.wire.bots.hold.resource.v0.audit;
 
-import com.github.mustachejava.DefaultMustacheFactory;
-import com.github.mustachejava.Mustache;
-import com.github.mustachejava.MustacheFactory;
 import com.wire.bots.hold.DAO.EventsDAO;
 import com.wire.bots.hold.filters.ServiceAuthorization;
-import com.wire.bots.hold.model.database.Event;
+import com.wire.bots.hold.model.EventModel;
+import com.wire.bots.hold.utils.HtmlGenerator;
 import com.wire.xenon.tools.Logger;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -17,16 +15,11 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.List;
 
 @Api
 @Path("/index.html")
 @Produces(MediaType.TEXT_HTML)
 public class IndexResource {
-    private final static MustacheFactory mf = new DefaultMustacheFactory();
     private final EventsDAO eventsDAO;
 
     public IndexResource(EventsDAO eventsDAO) {
@@ -41,9 +34,9 @@ public class IndexResource {
             @ApiResponse(code = 200, message = "Wire conversations")})
     public Response list() {
         try {
-            Model model = new Model();
+            EventModel model = new EventModel();
             model.events = eventsDAO.listConversations();
-            String html = execute(model);
+            String html = HtmlGenerator.execute(model, HtmlGenerator.TemplateType.INDEX);
 
             return Response.
                     ok(html, MediaType.TEXT_HTML).
@@ -55,22 +48,5 @@ public class IndexResource {
                     .status(500)
                     .build();
         }
-    }
-
-    private Mustache compileTemplate() {
-        String path = "templates/index.html";
-        return mf.compile(path);
-    }
-
-    private String execute(Object model) throws IOException {
-        Mustache mustache = compileTemplate();
-        try (StringWriter sw = new StringWriter()) {
-            mustache.execute(new PrintWriter(sw), model).flush();
-            return sw.toString();
-        }
-    }
-
-    static class Model {
-        List<Event> events;
     }
 }

--- a/src/main/java/com/wire/bots/hold/resource/v0/audit/IndexResource.java
+++ b/src/main/java/com/wire/bots/hold/resource/v0/audit/IndexResource.java
@@ -3,6 +3,7 @@ package com.wire.bots.hold.resource.v0.audit;
 import com.wire.bots.hold.DAO.EventsDAO;
 import com.wire.bots.hold.filters.ServiceAuthorization;
 import com.wire.bots.hold.model.EventModel;
+import com.wire.bots.hold.model.database.Event;
 import com.wire.bots.hold.utils.HtmlGenerator;
 import com.wire.xenon.tools.Logger;
 import io.swagger.annotations.Api;
@@ -36,6 +37,11 @@ public class IndexResource {
         try {
             EventModel model = new EventModel();
             model.events = eventsDAO.listConversations();
+            System.out.println("--- AAA");
+            for (Event e : model.events) {
+                System.out.println(e.conversationId + " _ " + e.conversationDomain);
+            }
+            System.out.println("--- BBB");
             String html = HtmlGenerator.execute(model, HtmlGenerator.TemplateType.INDEX);
 
             return Response.

--- a/src/main/java/com/wire/bots/hold/resource/v0/audit/IndexResource.java
+++ b/src/main/java/com/wire/bots/hold/resource/v0/audit/IndexResource.java
@@ -3,7 +3,6 @@ package com.wire.bots.hold.resource.v0.audit;
 import com.wire.bots.hold.DAO.EventsDAO;
 import com.wire.bots.hold.filters.ServiceAuthorization;
 import com.wire.bots.hold.model.EventModel;
-import com.wire.bots.hold.model.database.Event;
 import com.wire.bots.hold.utils.HtmlGenerator;
 import com.wire.xenon.tools.Logger;
 import io.swagger.annotations.Api;
@@ -37,11 +36,6 @@ public class IndexResource {
         try {
             EventModel model = new EventModel();
             model.events = eventsDAO.listConversations();
-            System.out.println("--- AAA");
-            for (Event e : model.events) {
-                System.out.println(e.conversationId + " _ " + e.conversationDomain);
-            }
-            System.out.println("--- BBB");
             String html = HtmlGenerator.execute(model, HtmlGenerator.TemplateType.INDEX);
 
             return Response.

--- a/src/main/java/com/wire/bots/hold/utils/Cache.java
+++ b/src/main/java/com/wire/bots/hold/utils/Cache.java
@@ -53,6 +53,11 @@ public class Cache {
     public File getProfileImage(User user) {
         File file = profiles.computeIfAbsent(user.id, k -> {
             try {
+                // TODO: Remove condition for null as String when new Xenon version is released
+                if (user.id.domain == null || user.id.domain.equals("null") || user.id.domain.isEmpty()) {
+                    user.id.domain = FALLBACK_DOMAIN;
+                }
+
                 return Helper.getProfile(api, user);
             } catch (Exception e) {
                 Logger.exception(e, "Cache.getProfileImage: userId: %s, ex: %s", user.id, e.getMessage());
@@ -68,10 +73,18 @@ public class Cache {
     public User getUser(QualifiedId userId) {
         return users.computeIfAbsent(userId, k -> {
             try {
+                // TODO: Remove condition for null as String when new Xenon version is released
+                if (userId.domain == null || userId.domain.equals("null") || userId.domain.isEmpty()) {
+                    userId.domain = FALLBACK_DOMAIN;
+                }
+
                 return api.getUser(userId);
             } catch (HttpException e) {
                 Logger.exception(e, "Cache.getUser: userId: %s, ex: %s", userId, e.getMessage());
-                throw new RuntimeException(e);
+                User user = new User();
+                user.id = userId;
+                user.name = userId.toString();
+                return user;
             }
         });
     }

--- a/src/main/java/com/wire/bots/hold/utils/HtmlGenerator.java
+++ b/src/main/java/com/wire/bots/hold/utils/HtmlGenerator.java
@@ -1,0 +1,73 @@
+package com.wire.bots.hold.utils;
+
+import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
+import com.github.mustachejava.MustacheFactory;
+import com.wire.xenon.tools.Logger;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public class HtmlGenerator {
+
+    private final static MustacheFactory mustacheFactory;
+
+    static {
+        mustacheFactory = new DefaultMustacheFactory();
+    }
+
+    private static Mustache indexTemplate() {
+        String path = "templates/index.html";
+        return mustacheFactory.compile(path);
+    }
+
+    private static Mustache eventsTemplate() {
+        String path = "templates/events.html";
+        return mustacheFactory.compile(path);
+    }
+
+    private static Mustache devicesTemplate() {
+        String path = "templates/devices.html";
+        return mustacheFactory.compile(path);
+    }
+
+    private static Mustache conversationTemplate() {
+        String path = "templates/conversation.html";
+        return mustacheFactory.compile(path);
+    }
+
+    public static String execute(Object model, TemplateType templateType) {
+        Mustache template = null;
+
+        switch (templateType) {
+            case INDEX:
+                template = indexTemplate();
+                break;
+            case EVENTS:
+                template = eventsTemplate();
+                break;
+            case DEVICES:
+                template = devicesTemplate();
+                break;
+            case CONVERSATION:
+                template = conversationTemplate();
+                break;
+        }
+
+        try (StringWriter sw = new StringWriter()) {
+            template.execute(new PrintWriter(sw), model).flush();
+            return sw.toString();
+        } catch (IOException exception) {
+            Logger.exception(exception, "Unable to compile HTML template");
+            return "";
+        }
+    }
+
+    public enum TemplateType {
+        INDEX,
+        EVENTS,
+        DEVICES,
+        CONVERSATION
+    }
+}

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -30,10 +30,10 @@
       {{#events}}
       <tr>
         <td>
-          <a href="/events/{{ conversationId }}">{{ conversationId }}</a>
+          <a href="/events/{{ conversationId }}/{{ conversationDomain }}">{{ conversationId }}_{{ conversationDomain }}</a>
         </td>
-        <td><a href="/conv/{{ conversationId }}">PDF</a></td>
-        <td><a href="/conv/{{ conversationId }}?html=true">HTML</a></td>
+        <td><a href="/conv/{{ conversationId }}/{{ conversationDomain }}">PDF</a></td>
+        <td><a href="/conv/{{ conversationId }}/{{ conversationDomain }}?html=true">HTML</a></td>
         <td>{{ time }}</td>
       </tr>
       {{/events}}

--- a/src/test/java/com/wire/bots/hold/resource/v0/audit/ConversationResourceTest.java
+++ b/src/test/java/com/wire/bots/hold/resource/v0/audit/ConversationResourceTest.java
@@ -1,0 +1,224 @@
+package com.wire.bots.hold.resource.v0.audit;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wire.bots.hold.Config;
+import com.wire.bots.hold.DAO.AccessDAO;
+import com.wire.bots.hold.DAO.EventsDAO;
+import com.wire.bots.hold.Service;
+import com.wire.bots.hold.model.EventModel;
+import com.wire.bots.hold.model.database.Event;
+import com.wire.bots.hold.utils.Cache;
+import com.wire.bots.hold.utils.HtmlGenerator;
+import com.wire.bots.hold.utils.HttpTestUtils;
+import com.wire.xenon.backend.models.QualifiedId;
+import com.wire.xenon.models.TextMessage;
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.DropwizardTestSupport;
+import org.apache.http.HttpStatus;
+import org.junit.*;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+public class ConversationResourceTest {
+    private static final String TOKEN = "dummy_token";
+    private static final String API_HOST = "dummy_api_host";
+    private static final String FALLBACK_DOMAIN = "dummy_domain";
+    private static final String USER_CLIENT_ID = "deviceId1";
+    private static final String USER_COOKIE = "userCookie1";
+
+    private static final QualifiedId userId  = new QualifiedId(UUID.randomUUID(), FALLBACK_DOMAIN);
+    private static final QualifiedId newConversationId = new QualifiedId(UUID.randomUUID(), UUID.randomUUID().toString());
+    private static final QualifiedId oldConversationId = new QualifiedId(UUID.randomUUID(), null);
+    private static final QualifiedId oldConversationIdWithDummyDomain = new QualifiedId(oldConversationId.id, FALLBACK_DOMAIN);
+
+    private static final DropwizardTestSupport<Config> SUPPORT = new DropwizardTestSupport<>(
+        Service.class,
+        "hold.yaml",
+        ConfigOverride.config("token", TOKEN),
+        ConfigOverride.config("apiHost", API_HOST),
+        ConfigOverride.config("server.applicationConnectors[0].type", "http")
+    );
+
+    private static EventsDAO eventsDAO;
+    private static AccessDAO accessDAO;
+    private static Client client;
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeClass
+    public static void before() throws Exception {
+        SUPPORT.before();
+        client = HttpTestUtils.createHttpClient(
+            SUPPORT.getConfiguration(),
+            SUPPORT.getEnvironment()
+        );
+
+        Service app = SUPPORT.getApplication();
+        eventsDAO = app.getJdbi().onDemand(EventsDAO.class);
+        accessDAO = app.getJdbi().onDemand(AccessDAO.class);
+
+        insertDummyEvents();
+    }
+
+    @AfterClass
+    public static void after() {
+        client.close();
+        SUPPORT.after();
+    }
+
+    @Before
+    public void beforeEach() {
+        // Clears cached domain
+        Cache.setFallbackDomain(null);
+    }
+
+    @Before
+    public void afterEach() {
+        // Clears cached domain
+        Cache.setFallbackDomain(null);
+    }
+
+    @Test
+    public void givenRequestWithIdAndDomain_whenGettingConversationListInHtml_thenHTMLIsGeneratedCorrectly() {
+        final Response response = getConversationList(
+            newConversationId.id,
+            newConversationId.domain,
+            true
+        );
+
+        assert response.getStatus() == HttpStatus.SC_OK;
+        String result = response.readEntity(String.class);
+
+        List<Event> events = eventsDAO.listAllAsc(newConversationId.id, newConversationId.domain);
+        EventModel model = new EventModel();
+        model.events = events;
+
+        String expectedResult = HtmlGenerator.execute(model, HtmlGenerator.TemplateType.CONVERSATION);
+        assert expectedResult.equals(result);
+    }
+
+    @Test
+    public void givenRequestOnlyWithId_whenGettingConversationListInHtml_thenHTMLIsGeneratedCorrectly() {
+        Cache.setFallbackDomain(FALLBACK_DOMAIN);
+
+        final Response response = getConversationList(
+            oldConversationId.id,
+            oldConversationId.domain,
+            true
+        );
+
+        assert response.getStatus() == HttpStatus.SC_OK;
+        String result = response.readEntity(String.class);
+
+        List<Event> events = eventsDAO.listAllDefaultDomainAsc(oldConversationId.id, FALLBACK_DOMAIN);
+        EventModel model = new EventModel();
+        model.events = events;
+
+        String expectedResult = HtmlGenerator.execute(model, HtmlGenerator.TemplateType.CONVERSATION);
+        assert expectedResult.equals(result);
+    }
+
+    @Test
+    public void givenRequestWithIdAndFallbackDomain_whenGettingConversationListInHtml_thenHTMLIsGeneratedCorrectly() {
+        Cache.setFallbackDomain(FALLBACK_DOMAIN);
+
+        final Response response = getConversationList(
+            oldConversationIdWithDummyDomain.id,
+            oldConversationIdWithDummyDomain.domain,
+            true
+        );
+
+        assert response.getStatus() == HttpStatus.SC_OK;
+        String result = response.readEntity(String.class);
+
+        List<Event> events = eventsDAO.listAllDefaultDomainAsc(oldConversationIdWithDummyDomain.id, oldConversationIdWithDummyDomain.domain);
+        EventModel model = new EventModel();
+        model.events = events;
+
+        String expectedResult = HtmlGenerator.execute(model, HtmlGenerator.TemplateType.CONVERSATION);
+        assert expectedResult.equals(result);
+    }
+
+    @Test
+    public void givenRequestWithIdAndDomain_whenGettingConversationListInPDF_thenPDFIsGeneratedCorrectly() throws Exception {
+        final Response response = getConversationList(
+            newConversationId.id,
+            newConversationId.domain,
+            false
+        );
+
+        assert response.getStatus() == HttpStatus.SC_OK;
+        assert response.getMediaType().toString().equals("application/pdf");
+    }
+
+    private Response getConversationList(UUID conversationId, String conversationDomain, boolean isHtml) {
+        String extraParameters = conversationId.toString();
+        if (conversationDomain != null && !conversationDomain.isEmpty()) {
+            extraParameters = extraParameters + "/" + conversationDomain;
+        }
+
+        System.out.println("extraParams : " + extraParameters);
+
+        return client
+            .target("http://localhost:" + SUPPORT.getLocalPort())
+            .path("conv")
+            .path(extraParameters)
+            .queryParam("html", isHtml)
+            .request("application/pdf")
+            .header(HttpHeaders.AUTHORIZATION, TOKEN)
+            .accept(MediaType.APPLICATION_JSON)
+            .get();
+    }
+
+    private static void insertDummyEvents() throws JsonProcessingException {
+        // Insert User
+        accessDAO.insert(
+            userId.id,
+            userId.domain,
+            USER_CLIENT_ID,
+            USER_COOKIE
+        );
+        accessDAO.update(
+            userId.id,
+            userId.domain,
+            TOKEN,
+            USER_COOKIE
+        );
+
+        // Date format
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+
+        // New conversation with ID and Domain
+        insertTextMessage(newConversationId, dateFormat);
+        insertTextMessage(newConversationId, dateFormat);
+        insertTextMessage(newConversationId, dateFormat);
+
+        // Old conversation with ID but without Domain
+        insertTextMessage(oldConversationIdWithDummyDomain, dateFormat);
+        insertTextMessage(oldConversationId, dateFormat);
+        insertTextMessage(oldConversationId, dateFormat);
+    }
+
+    private static void insertTextMessage(QualifiedId conversationId, DateFormat dateFormat) throws JsonProcessingException {
+        final String type = "conversation.otr-message-add.new-text";
+        final UUID eventId = UUID.randomUUID();
+        final UUID messageId = UUID.randomUUID();
+        final String time = dateFormat.format(new Date());
+
+        final TextMessage textMessage = new TextMessage(eventId, messageId, conversationId, USER_CLIENT_ID, userId, time);
+        textMessage.addMention(new QualifiedId(UUID.randomUUID(), FALLBACK_DOMAIN), 0, 5);
+        textMessage.setText("Text for: " + conversationId.id + " - " + conversationId.domain);
+
+        String payload = mapper.writeValueAsString(textMessage);
+
+        eventsDAO.insert(eventId, conversationId.id, conversationId.domain, userId.id, userId.domain, type, payload);
+    }
+}

--- a/src/test/java/com/wire/bots/hold/resource/v0/audit/ConversationResourceTest.java
+++ b/src/test/java/com/wire/bots/hold/resource/v0/audit/ConversationResourceTest.java
@@ -165,8 +165,6 @@ public class ConversationResourceTest {
             extraParameters = extraParameters + "/" + conversationDomain;
         }
 
-        System.out.println("extraParams : " + extraParameters);
-
         return client
             .target("http://localhost:" + SUPPORT.getLocalPort())
             .path("conv")

--- a/src/test/java/com/wire/bots/hold/resource/v0/audit/EventsResourceTest.java
+++ b/src/test/java/com/wire/bots/hold/resource/v0/audit/EventsResourceTest.java
@@ -1,0 +1,199 @@
+package com.wire.bots.hold.resource.v0.audit;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wire.bots.hold.Config;
+import com.wire.bots.hold.DAO.EventsDAO;
+import com.wire.bots.hold.Service;
+import com.wire.bots.hold.model.EventModel;
+import com.wire.bots.hold.model.database.Event;
+import com.wire.bots.hold.utils.Cache;
+import com.wire.bots.hold.utils.HtmlGenerator;
+import com.wire.bots.hold.utils.HttpTestUtils;
+import com.wire.xenon.backend.models.QualifiedId;
+import com.wire.xenon.models.TextMessage;
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.DropwizardTestSupport;
+import org.apache.http.HttpStatus;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+public class EventsResourceTest {
+    private static final String TOKEN = "dummy_token";
+    private static final String API_HOST = "dummy_api_host";
+    private static final String FALLBACK_DOMAIN = "dummy_domain";
+
+    private static final QualifiedId newConversationId = new QualifiedId(UUID.randomUUID(), UUID.randomUUID().toString());
+    private static final QualifiedId oldConversationId = new QualifiedId(UUID.randomUUID(), null);
+    private static final QualifiedId oldConversationIdWithDummyDomain = new QualifiedId(oldConversationId.id, FALLBACK_DOMAIN);
+
+    private static final DropwizardTestSupport<Config> SUPPORT = new DropwizardTestSupport<>(
+        Service.class,
+        "hold.yaml",
+        ConfigOverride.config("token", TOKEN),
+        ConfigOverride.config("apiHost", API_HOST)
+    );
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private static Client client;
+    private static EventsDAO eventsDAO;
+
+    @BeforeClass
+    public static void before() throws Exception {
+        SUPPORT.before();
+        client = HttpTestUtils.createHttpClient(
+            SUPPORT.getConfiguration(),
+            SUPPORT.getEnvironment()
+        );
+
+        Service app = SUPPORT.getApplication();
+        eventsDAO = app.getJdbi().onDemand(EventsDAO.class);
+
+        insertDummyEvents();
+    }
+
+    @AfterClass
+    public static void after() {
+        client.close();
+        SUPPORT.after();
+
+    }
+
+    @Before
+    public void beforeEach() {
+        // Clears cached domain
+        Cache.setFallbackDomain(null);
+    }
+
+    @Before
+    public void afterEach() {
+        // Clears cached domain
+        Cache.setFallbackDomain(null);
+    }
+
+    @Test
+    public void givenRequestWithIdAndDomain_whenGettingEvents_thenGetEventsAndGenerateHTMLCorrectly() {
+        final Response response = getEvents(
+            newConversationId.id,
+            newConversationId.domain
+        );
+
+        assert response.getStatus() == HttpStatus.SC_OK;
+        String eventsHTML = response.readEntity(String.class);
+
+        List<Event> events = eventsDAO.listAll(newConversationId.id, newConversationId.domain);
+        EventModel model = new EventModel();
+        model.events = events;
+
+        String expectedResult = HtmlGenerator.execute(model, HtmlGenerator.TemplateType.EVENTS);
+        assert expectedResult.equals(eventsHTML);
+
+        for (Event event : events) {
+            assert eventsHTML.contains(event.conversationId.toString());
+            assert eventsHTML.contains(event.conversationDomain);
+        }
+    }
+
+    @Test
+    public void givenRequestOnlyWithId_whenGettingEvents_thenGetEventsAndGenerateHTMLCorrectly() {
+        Cache.setFallbackDomain(FALLBACK_DOMAIN);
+
+        final Response response = getEvents(
+            oldConversationId.id,
+            oldConversationId.domain
+        );
+
+        assert response.getStatus() == HttpStatus.SC_OK;
+        String eventsHTML = response.readEntity(String.class);
+
+        List<Event> events = eventsDAO.listAllDefaultDomain(oldConversationId.id, FALLBACK_DOMAIN);
+        EventModel model = new EventModel();
+        model.events = events;
+
+        String expectedResult = HtmlGenerator.execute(model, HtmlGenerator.TemplateType.EVENTS);
+        assert expectedResult.equals(eventsHTML);
+
+        for (Event event : events) {
+            assert eventsHTML.contains(event.conversationId.toString());
+        }
+    }
+
+    @Test
+    public void givenRequestWithIdAndFallbackDomain_whenGettingEvents_thenGetEventsAndGenerateHTMLCorrectly() {
+        Cache.setFallbackDomain(FALLBACK_DOMAIN);
+
+        final Response response = getEvents(
+            oldConversationIdWithDummyDomain.id,
+            oldConversationIdWithDummyDomain.domain
+        );
+
+        assert response.getStatus() == HttpStatus.SC_OK;
+        String eventsHTML = response.readEntity(String.class);
+
+        List<Event> events = eventsDAO.listAllDefaultDomain(oldConversationIdWithDummyDomain.id, oldConversationIdWithDummyDomain.domain);
+        EventModel model = new EventModel();
+        model.events = events;
+
+        String expectedResult = HtmlGenerator.execute(model, HtmlGenerator.TemplateType.EVENTS);
+        assert expectedResult.equals(eventsHTML);
+
+        for (Event event : events) {
+            assert eventsHTML.contains(event.conversationId.toString());
+        }
+    }
+
+    private Response getEvents(UUID conversationId, String conversationDomain) {
+        String conversationIdAndDomain = conversationId.toString();
+        if (conversationDomain != null && !conversationDomain.isEmpty()) {
+            conversationIdAndDomain = conversationIdAndDomain + "/" + conversationDomain;
+        }
+
+        return client
+            .target("http://localhost:" + SUPPORT.getLocalPort())
+            .path("events")
+            .path(conversationIdAndDomain)
+            .request(MediaType.TEXT_HTML)
+            .header(HttpHeaders.AUTHORIZATION, TOKEN)
+            .accept(MediaType.APPLICATION_JSON)
+            .get();
+    }
+
+    private static void insertDummyEvents() throws JsonProcessingException {
+        // New conversation with ID and Domain
+        insertTextMessage(newConversationId);
+        insertTextMessage(newConversationId);
+        insertTextMessage(newConversationId);
+
+        // Old conversation with ID but without Domain
+        insertTextMessage(oldConversationIdWithDummyDomain);
+        insertTextMessage(oldConversationId);
+        insertTextMessage(oldConversationId);
+    }
+
+    private static void insertTextMessage(QualifiedId conversationId) throws JsonProcessingException {
+        final String type = "conversation.otr-message-add.new-text";
+        final UUID eventId = UUID.randomUUID();
+        final UUID messageId = UUID.randomUUID();
+        final String clientId = UUID.randomUUID().toString();
+        final QualifiedId userId  = new QualifiedId(UUID.randomUUID(), FALLBACK_DOMAIN);
+        final String time = new Date().toString();
+
+        final TextMessage textMessage = new TextMessage(eventId, messageId, conversationId, clientId, userId, time);
+        textMessage.addMention(new QualifiedId(UUID.randomUUID(), FALLBACK_DOMAIN), 0, 5);
+        textMessage.setText("Text for: " + conversationId.id + " - " + conversationId.domain);
+
+        String payload = mapper.writeValueAsString(textMessage);
+
+        eventsDAO.insert(eventId, conversationId.id, conversationId.domain, userId.id, userId.domain, type, payload);
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Audit APIs doesn't have support for receiving domain as parameter

### Causes (Optional)

Not implemented

### Solutions

* Revert Dropwizard version to 2.1.2
* Add condition to add fallback domain when getting user and profile image
* Add support in API path for /domain for ConversationResource and EventsResource
* Add verification of which DB query to run based on received domain on ConversationResource and EventsResource
* Moved Mustache generator into a proper file: HtmlGenerator and removed duplicated code
* Add tests for ConversationResource and EventsResource
* Return conversationDomain from eventsDAO.listConversations
* Add conversation domain to index.html template

### Dependencies (Optional)

Currently we are also checking if user domain is `"null"`, which will be changed/removed later when there is a new version of Xenon available.

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

Either run locally or deployed in our internal VM:
- Can run these endpoints:
```
https://URL/conv/conversation_id/conversation_domain?html=false
https://URL/conv/conversation_id/conversation_domain?html=true
https://URL/events/conversation_id/conversation_domain
```
