### PR TITLE
feat(remove-mls-data-on-device-being-removed) #WPB-12155

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ This is Legal Hold Service for Wire.
 ## Environment variables
 - SERVICE_TOKEN: <mandatory>. Must be set to some random value (at least 16 alphanumeric chars)
 - WIRE_API_HOST: <optional>. Your Wire Backend host. Default: https://prod-nginz-https.wire.com
+- CORE_CRYPTO_PASSWORD: <mandatory>. Your MLS folder password
 - DB_DRIVER: <optional>. Default: org.postgresql.Driver
 - DB_URL: <optional>. Default: jdbc:postgresql://localhost/legalhold
 - DB_USER: <optional>
@@ -21,6 +22,7 @@ docker run \
 -e DB_USER='admin' \
 -e DB_PASSWORD='s3cret' \
 -e SERVICE_TOKEN='secr3t' \
+-e CORE_CRYPTO_PASSWORD='secr3t' \
 -p 80:8080 \
 --name secure-hold --rm quay.io/wire/legalhold:1.0.4
 ``` 

--- a/src/main/java/com/wire/bots/hold/service/DeviceManagementService.java
+++ b/src/main/java/com/wire/bots/hold/service/DeviceManagementService.java
@@ -2,6 +2,7 @@ package com.wire.bots.hold.service;
 
 import com.wire.bots.cryptobox.CryptoException;
 import com.wire.bots.hold.DAO.AccessDAO;
+import com.wire.bots.hold.model.database.LHAccess;
 import com.wire.bots.hold.model.dto.InitializedDeviceDTO;
 import com.wire.bots.hold.utils.CryptoDatabaseFactory;
 
@@ -164,6 +165,18 @@ public class DeviceManagementService {
      * @throws CryptoException
      */
     public void removeDevice(QualifiedId userId, UUID teamId) throws IOException, CryptoException {
+        // MLS
+        LHAccess userAccess = accessDAO.get(userId.id, userId.domain);
+        if (userAccess != null) {
+            API api = new API(client, null, userAccess.token);
+            if (api.isMlsEnabled()) {
+                try (CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(userAccess.clientId, coreCryptoPassword)) {
+                    cryptoMlsClient.wipe();
+                }
+            }
+        }
+
+        // Proteus
         try (Crypto crypto = cf.create(userId)) {
             crypto.purge();
 

--- a/src/test/java/com/wire/bots/hold/service/DeviceManagementServiceTest.java
+++ b/src/test/java/com/wire/bots/hold/service/DeviceManagementServiceTest.java
@@ -1,6 +1,7 @@
 package com.wire.bots.hold.service;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.wire.bots.cryptobox.CryptoException;
 import com.wire.bots.hold.Config;
 import com.wire.bots.hold.DAO.AccessDAO;
 import com.wire.bots.hold.DAO.MetadataDAO;
@@ -10,7 +11,12 @@ import com.wire.bots.hold.utils.Cache;
 import com.wire.bots.hold.utils.CryptoDatabaseFactory;
 import com.wire.bots.hold.utils.HttpTestUtils;
 import com.wire.xenon.backend.models.QualifiedId;
+import com.wire.xenon.crypto.Crypto;
 import com.wire.xenon.crypto.mls.CryptoMlsClient;
+import com.wire.xenon.models.otr.Missing;
+import com.wire.xenon.models.otr.PreKey;
+import com.wire.xenon.models.otr.PreKeys;
+import com.wire.xenon.models.otr.Recipients;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.DropwizardTestSupport;
 import org.junit.*;
@@ -23,6 +29,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.UUID;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -40,6 +47,7 @@ public class DeviceManagementServiceTest {
     private static Client client;
     private static final WireMockServer wireMockServer = new WireMockServer(8090);
     private AccessDAO accessDAO;
+    private CryptoDatabaseFactory cryptoFactory;
     private DeviceManagementService deviceManagementService;
 
     // Consts
@@ -64,14 +72,15 @@ public class DeviceManagementServiceTest {
     }
 
     @Before
-    public void before() {
+    public void before() throws CryptoException {
         wireMockServer.start();
         configureFor("localhost", 8090);
 
         stubFor(get(urlEqualTo("/api-version"))
             .willReturn(okJson(apiVersionV6)));
 
-        CryptoDatabaseFactory cryptoFactory = mock(CryptoDatabaseFactory.class);
+        cryptoFactory = mock(CryptoDatabaseFactory.class);
+        when(cryptoFactory.create(userId)).thenReturn(mockedCrypto);
         accessDAO = mock(AccessDAO.class);
 
         deviceManagementService = new DeviceManagementService(
@@ -460,24 +469,19 @@ public class DeviceManagementServiceTest {
     }
 
     @Test
-    public void givenUnknownUser_whenRemovingDevice_thenNoMlsCallsAreMade() {
+    public void givenUnknownUser_whenRemovingDevice_thenNoMlsCallsAreMade() throws IOException, CryptoException {
         // given
         when(accessDAO.get(userId.id, userId.domain)).thenReturn(null);
 
         // when
-        try {
-            deviceManagementService.removeDevice(userId, teamId);
-        } catch (Exception exception) {
-            assert exception instanceof NullPointerException;
-            assert exception.getMessage().equals("Cannot invoke \"com.wire.xenon.crypto.Crypto.purge()\" because \"crypto\" is null");
-        }
+        deviceManagementService.removeDevice(userId, teamId);
 
         // then
         verify(accessDAO, times(1)).get(userId.id, userId.domain);
     }
 
     @Test
-    public void givenKnownUser_whenRemovingDeviceAndMlsIsDisabled_thenNoWipeIsCalled() {
+    public void givenKnownUser_whenRemovingDeviceAndMlsIsDisabled_thenNoWipeIsCalled() throws IOException, CryptoException {
         // given
         Path path = Paths.get("mls/" + clientId);
         try (CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(clientId, coreCryptoPassword)) {
@@ -498,12 +502,7 @@ public class DeviceManagementServiceTest {
             .willReturn(okJson(disabledMlsFeatureConfigJsonResponse)));
 
         // when
-        try {
-            deviceManagementService.removeDevice(userId, teamId);
-        } catch (Exception exception) {
-            assert exception instanceof NullPointerException;
-            assert exception.getMessage().equals("Cannot invoke \"com.wire.xenon.crypto.Crypto.purge()\" because \"crypto\" is null");
-        }
+        deviceManagementService.removeDevice(userId, teamId);
 
         // then
         verify(accessDAO, times(1)).get(userId.id, userId.domain);
@@ -511,7 +510,7 @@ public class DeviceManagementServiceTest {
     }
 
     @Test
-    public void givenKnownUser_whenRemovingDeviceAndMlsIsEnabled_thenWipeIsCalled() {
+    public void givenKnownUser_whenRemovingDeviceAndMlsIsEnabled_thenWipeIsCalled() throws IOException, CryptoException {
         // given
         stubFor(get(urlEqualTo("/v6/feature-configs"))
             .willReturn(okJson(enabledMlsFeatureConfigJsonResponse)));
@@ -535,17 +534,64 @@ public class DeviceManagementServiceTest {
         when(accessDAO.get(userId.id, userId.domain)).thenReturn(lhAccess);
 
         // when
-        try {
-            deviceManagementService.removeDevice(userId, teamId);
-        } catch (Exception exception) {
-            assert exception instanceof NullPointerException;
-            assert exception.getMessage().equals("Cannot invoke \"com.wire.xenon.crypto.Crypto.purge()\" because \"crypto\" is null");
-        }
+        deviceManagementService.removeDevice(userId, teamId);
 
         // then
         verify(accessDAO, times(1)).get(userId.id, userId.domain);
         assert Files.notExists(path);
     }
+
+    Crypto mockedCrypto = new Crypto() {
+        @Override
+        public byte[] getIdentity() throws CryptoException {
+            return new byte[0];
+        }
+
+        @Override
+        public byte[] getLocalFingerprint() throws CryptoException {
+            return new byte[0];
+        }
+
+        @Override
+        public PreKey newLastPreKey() throws CryptoException {
+            return null;
+        }
+
+        @Override
+        public ArrayList<PreKey> newPreKeys(int from, int count) throws CryptoException {
+            return null;
+        }
+
+        @Override
+        public Recipients encrypt(PreKeys preKeys, byte[] content) throws CryptoException {
+            return null;
+        }
+
+        @Override
+        public Recipients encrypt(Missing missing, byte[] content) throws CryptoException {
+            return null;
+        }
+
+        @Override
+        public String decrypt(QualifiedId userId, String clientId, String cypher) throws CryptoException {
+            return "";
+        }
+
+        @Override
+        public boolean isClosed() {
+            return false;
+        }
+
+        @Override
+        public void purge() throws IOException {
+
+        }
+
+        @Override
+        public void close() throws IOException {
+
+        }
+    };
 
     private static final String enabledMlsFeatureConfigJsonResponse = """
         {

--- a/src/test/java/com/wire/bots/hold/service/DeviceManagementServiceTest.java
+++ b/src/test/java/com/wire/bots/hold/service/DeviceManagementServiceTest.java
@@ -5,10 +5,12 @@ import com.wire.bots.hold.Config;
 import com.wire.bots.hold.DAO.AccessDAO;
 import com.wire.bots.hold.DAO.MetadataDAO;
 import com.wire.bots.hold.Service;
+import com.wire.bots.hold.model.database.LHAccess;
 import com.wire.bots.hold.utils.Cache;
 import com.wire.bots.hold.utils.CryptoDatabaseFactory;
 import com.wire.bots.hold.utils.HttpTestUtils;
 import com.wire.xenon.backend.models.QualifiedId;
+import com.wire.xenon.crypto.mls.CryptoMlsClient;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.DropwizardTestSupport;
 import org.junit.*;
@@ -18,6 +20,9 @@ import javax.ws.rs.client.Client;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.UUID;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -33,12 +38,8 @@ public class DeviceManagementServiceTest {
         ConfigOverride.config("token", TOKEN),
         ConfigOverride.config("apiHost", API_HOST));
     private static Client client;
-
     private static final WireMockServer wireMockServer = new WireMockServer(8090);
-
-    private CryptoDatabaseFactory cryptoFactory;
     private AccessDAO accessDAO;
-    private String coreCryptoPassword;
     private DeviceManagementService deviceManagementService;
 
     // Consts
@@ -46,6 +47,7 @@ public class DeviceManagementServiceTest {
     private static final UUID teamId = UUID.randomUUID();
     private static final String clientId = UUID.randomUUID().toString();
     private static final String refreshToken = UUID.randomUUID().toString();
+    private static final String coreCryptoPassword = "secr3t";
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -69,9 +71,8 @@ public class DeviceManagementServiceTest {
         stubFor(get(urlEqualTo("/api-version"))
             .willReturn(okJson(apiVersionV6)));
 
-        cryptoFactory = mock(CryptoDatabaseFactory.class);
+        CryptoDatabaseFactory cryptoFactory = mock(CryptoDatabaseFactory.class);
         accessDAO = mock(AccessDAO.class);
-        coreCryptoPassword = "secr3t";
 
         deviceManagementService = new DeviceManagementService(
             accessDAO,
@@ -456,6 +457,94 @@ public class DeviceManagementServiceTest {
             clientId,
             refreshToken
         );
+    }
+
+    @Test
+    public void givenUnknownUser_whenRemovingDevice_thenNoMlsCallsAreMade() {
+        // given
+        when(accessDAO.get(userId.id, userId.domain)).thenReturn(null);
+
+        // when
+        try {
+            deviceManagementService.removeDevice(userId, teamId);
+        } catch (Exception exception) {
+            assert exception instanceof NullPointerException;
+            assert exception.getMessage().equals("Cannot invoke \"com.wire.xenon.crypto.Crypto.purge()\" because \"crypto\" is null");
+        }
+
+        // then
+        verify(accessDAO, times(1)).get(userId.id, userId.domain);
+    }
+
+    @Test
+    public void givenKnownUser_whenRemovingDeviceAndMlsIsDisabled_thenNoWipeIsCalled() {
+        // given
+        Path path = Paths.get("mls/" + clientId);
+        try (CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(clientId, coreCryptoPassword)) {
+            assert cryptoMlsClient != null;
+            assert Files.exists(path);
+        }
+
+        LHAccess lhAccess = new LHAccess();
+        lhAccess.last = UUID.randomUUID();
+        lhAccess.userId = new QualifiedId(userId.id, userId.domain);
+        lhAccess.clientId = clientId;
+        lhAccess.token = refreshToken;
+        lhAccess.cookie = "cookie";
+        lhAccess.enabled = true;
+
+        when(accessDAO.get(userId.id, userId.domain)).thenReturn(lhAccess);
+        stubFor(get(urlEqualTo("/v6/feature-configs"))
+            .willReturn(okJson(disabledMlsFeatureConfigJsonResponse)));
+
+        // when
+        try {
+            deviceManagementService.removeDevice(userId, teamId);
+        } catch (Exception exception) {
+            assert exception instanceof NullPointerException;
+            assert exception.getMessage().equals("Cannot invoke \"com.wire.xenon.crypto.Crypto.purge()\" because \"crypto\" is null");
+        }
+
+        // then
+        verify(accessDAO, times(1)).get(userId.id, userId.domain);
+        assert Files.exists(path);
+    }
+
+    @Test
+    public void givenKnownUser_whenRemovingDeviceAndMlsIsEnabled_thenWipeIsCalled() {
+        // given
+        stubFor(get(urlEqualTo("/v6/feature-configs"))
+            .willReturn(okJson(enabledMlsFeatureConfigJsonResponse)));
+        stubFor(get(urlEqualTo("/v6/mls/public-keys"))
+            .willReturn(okJson(mlsPublicKeysSuccessResponse)));
+
+        Path path = Paths.get("mls/" + clientId);
+        try (CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(clientId, coreCryptoPassword)) {
+            assert cryptoMlsClient != null;
+            assert Files.exists(path);
+        }
+
+        LHAccess lhAccess = new LHAccess();
+        lhAccess.last = UUID.randomUUID();
+        lhAccess.userId = new QualifiedId(userId.id, userId.domain);
+        lhAccess.clientId = clientId;
+        lhAccess.token = refreshToken;
+        lhAccess.cookie = "cookie";
+        lhAccess.enabled = true;
+
+        when(accessDAO.get(userId.id, userId.domain)).thenReturn(lhAccess);
+
+        // when
+        try {
+            deviceManagementService.removeDevice(userId, teamId);
+        } catch (Exception exception) {
+            assert exception instanceof NullPointerException;
+            assert exception.getMessage().equals("Cannot invoke \"com.wire.xenon.crypto.Crypto.purge()\" because \"crypto\" is null");
+        }
+
+        // then
+        verify(accessDAO, times(1)).get(userId.id, userId.domain);
+        assert Files.notExists(path);
     }
 
     private static final String enabledMlsFeatureConfigJsonResponse = """


### PR DESCRIPTION
* Update README.md to include CORE_CRYPTO_PASSWORD
* Add call to Xenon CryptoMlsClient wipe() function in removeDevice
* Add tests for wipe mls data on device removed

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When removing a Device from Legalhold, we weren't removing MLS data (if MLS is enabled and user exists)

### Causes (Optional)

Not implemented.

### Solutions

Add verification if user exists and if MLS is enabled when calling `removeDevice` from `DeviceManagementService` then calling `CryptoMlsClient.wipe()`

### Dependencies (Optional)

Xenon 1.7.2
Helium 1.5.2

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

### Notes
We have a manual implementation to remove MLS data from Xenon for now until `CoreCrypto` releases a fix for `CoreCrypto.wipe()` function, the progress can be seen from #WPB-14514