### PR TITLE
fix(use client id to refresh tokens) #WPB-12153

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wire.bots</groupId>
     <artifactId>hold</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
 
     <name>Legal Hold</name>
     <description>Legal Hold Service For Wire</description>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.wire</groupId>
             <artifactId>helium</artifactId>
-            <version>1.5.2</version>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.smoketurner</groupId>

--- a/src/main/java/com/wire/bots/hold/NotificationProcessor.java
+++ b/src/main/java/com/wire/bots/hold/NotificationProcessor.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wire.bots.hold.DAO.AccessDAO;
 import com.wire.bots.hold.model.database.LHAccess;
+import com.wire.bots.hold.utils.LoginClientExtension;
 import com.wire.helium.API;
-import com.wire.helium.LoginClient;
 import com.wire.helium.models.Access;
 import com.wire.helium.models.Event;
 import com.wire.helium.models.NotificationList;
@@ -16,7 +16,6 @@ import com.wire.xenon.exceptions.HttpException;
 import com.wire.xenon.tools.Logger;
 
 import javax.ws.rs.client.Client;
-import javax.ws.rs.core.Cookie;
 import java.util.List;
 import java.util.UUID;
 import java.util.logging.Level;
@@ -48,31 +47,14 @@ public class NotificationProcessor implements Runnable {
         }
     }
 
-    private Access getAccess(Cookie cookie) throws HttpException {
-        LoginClient loginClient = new LoginClient(client);
-        return loginClient.renewAccessToken(cookie);
-    }
-
     private void process(LHAccess device) {
         try {
             Logger.debug("`GET /notifications`: user: %s, last: %s", device.userId, device.last);
 
-            String cookieValue = device.cookie;
+            final Access access = LoginClientExtension.refreshToken(client, device.clientId, device.cookie);
+            accessDAO.update(device.userId.id, device.userId.domain, access.getAccessToken(), access.getCookie().value);
 
-            Cookie cookie = new Cookie("zuid", device.cookie);
-
-            Access access = getAccess(cookie);
-
-            if (access.getCookie() != null) {
-                Logger.info("Set-Cookie: user: %s", device.userId);
-                cookieValue = access.getCookie().value;
-            }
-
-            accessDAO.update(device.userId.id, device.userId.domain, access.getAccessToken(), cookieValue);
-
-            device.token = access.getAccessToken();
-
-            final API api = new API(client, null, device.token);
+            final API api = new API(client, null, access.getAccessToken());
             NotificationList notificationList = api.retrieveNotifications(
                 device.clientId,
                 device.last,

--- a/src/main/java/com/wire/bots/hold/service/DeviceManagementService.java
+++ b/src/main/java/com/wire/bots/hold/service/DeviceManagementService.java
@@ -5,8 +5,9 @@ import com.wire.bots.hold.DAO.AccessDAO;
 import com.wire.bots.hold.model.database.LHAccess;
 import com.wire.bots.hold.model.dto.InitializedDeviceDTO;
 import com.wire.bots.hold.utils.CryptoDatabaseFactory;
-
+import com.wire.bots.hold.utils.LoginClientExtension;
 import com.wire.helium.API;
+import com.wire.helium.models.Access;
 import com.wire.xenon.WireClientBase;
 import com.wire.xenon.backend.models.Conversation;
 import com.wire.xenon.backend.models.QualifiedId;
@@ -92,17 +93,17 @@ public class DeviceManagementService {
      * @throws RuntimeException when any of the (parallel or not) MLS tasks fails. Or if inserting refreshToken to Database fails.
      */
     public void confirmDevice(QualifiedId userId, UUID teamId, String clientId, String refreshToken) throws RuntimeException {
-        API api = new API(client, null, refreshToken);
+        final Access access = LoginClientExtension.refreshToken(client, clientId, refreshToken);
+        API api = new API(client, null, access.accessToken);
+
         if (api.isMlsEnabled()) {
-            try (CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(clientId, coreCryptoPassword)) {
+            try (CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(clientId, userId, coreCryptoPassword)) {
                 // CryptoMlsClient will be closed from `try` with resource so there is no issue passing
                 // Crypto as null, as we will not be calling wireClientBase.close()
                 WireClientBase wireClientBase = new WireClientBase(api, null, cryptoMlsClient, null);
 
-                CompletableFuture<Void> mlsPublicKeyFuture = CompletableFuture.supplyAsync(() -> {
-                    wireClientBase.updateClientWithMlsPublicKey();
-                    return null;
-                });
+                wireClientBase.updateClientWithMlsPublicKey();
+
                 CompletableFuture<Void> mlsKeyPackagesFuture = CompletableFuture.supplyAsync(() -> {
                     wireClientBase.uploadMlsKeyPackages(KEY_PACKAGE_AMOUNT);
                     return null;
@@ -114,7 +115,6 @@ public class DeviceManagementService {
                    .collect(Collectors.toList()));
 
                 CompletableFuture<Void> combinedFutures = CompletableFuture.allOf(
-                    mlsPublicKeyFuture,
                     mlsKeyPackagesFuture,
                     conversationsFuture
                 ).exceptionally(throwable -> {
@@ -127,7 +127,10 @@ public class DeviceManagementService {
 
                 combinedFutures.get();
 
-                for (Conversation conversation : conversationsFuture.get()) {
+                final List<Conversation> mlsConversations = conversationsFuture.get();
+                Logger.info("Joining %d MLS conversations", mlsConversations.size());
+                for (Conversation conversation : mlsConversations) {
+                    Logger.info("Conversation ID: %s, Name: %s, GroupId: %s", conversation.id, conversation.name, conversation.mlsGroupId);
                     wireClientBase.joinMlsConversation(conversation.id, conversation.mlsGroupId);
                 }
             } catch (ExecutionException exception) {
@@ -141,7 +144,7 @@ public class DeviceManagementService {
         int insert = accessDAO.insert(userId.id,
             userId.domain,
             clientId,
-            refreshToken);
+            access.getCookie().value);
 
         if (0 == insert) {
             Logger.error("ConfirmResource: Failed to insert Access %s:%s",
@@ -170,7 +173,7 @@ public class DeviceManagementService {
         if (userAccess != null) {
             API api = new API(client, null, userAccess.token);
             if (api.isMlsEnabled()) {
-                try (CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(userAccess.clientId, coreCryptoPassword)) {
+                try (CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(userAccess.clientId, userId, coreCryptoPassword)) {
                     cryptoMlsClient.wipe();
                 }
             }

--- a/src/main/java/com/wire/bots/hold/utils/HoldClientRepo.java
+++ b/src/main/java/com/wire/bots/hold/utils/HoldClientRepo.java
@@ -32,7 +32,7 @@ public class HoldClientRepo {
         final API api = new API(httpClient, conversationId, single.token);
 
         // for receiving notifications
-        final CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(deviceId, coreCryptoPassword);
+        final CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(deviceId, userId, coreCryptoPassword);
         return new HoldWireClient(userId, deviceId, conversationId, cryptoMlsClient, crypto, api);
     }
 }

--- a/src/main/java/com/wire/bots/hold/utils/LoginClientExtension.java
+++ b/src/main/java/com/wire/bots/hold/utils/LoginClientExtension.java
@@ -1,0 +1,28 @@
+package com.wire.bots.hold.utils;
+
+import com.wire.helium.LoginClient;
+import com.wire.helium.models.Access;
+import com.wire.xenon.exceptions.HttpException;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Cookie;
+
+public class LoginClientExtension {
+    public static Access refreshToken(Client client, String clientId, String cookieValue) {
+        try {
+            LoginClient loginClient = new LoginClient(client);
+            Cookie cookie = new Cookie("zuid", cookieValue);
+            Access access = loginClient.renewAccessToken(clientId, cookie);
+            if (access.getCookie() == null) {
+                // If the cookie is not returned, we need sett the previous one as fallback
+                com.wire.helium.models.Cookie cookie1 = new com.wire.helium.models.Cookie();
+                cookie1.name = "zuid";
+                cookie1.value = cookieValue;
+                access.setCookie(cookie1);
+            }
+            return access;
+        } catch (HttpException e) {
+            throw new RuntimeException("LoginException, cannot fetch access token with the provided refreshToken", e);
+        }
+    }
+}

--- a/src/test/java/com/wire/bots/hold/service/DeviceManagementServiceTest.java
+++ b/src/test/java/com/wire/bots/hold/service/DeviceManagementServiceTest.java
@@ -22,7 +22,6 @@ import io.dropwizard.testing.DropwizardTestSupport;
 import org.junit.*;
 
 import javax.ws.rs.client.Client;
-
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -33,6 +32,7 @@ import java.util.ArrayList;
 import java.util.UUID;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.*;
 
 public class DeviceManagementServiceTest {
@@ -47,7 +47,6 @@ public class DeviceManagementServiceTest {
     private static Client client;
     private static final WireMockServer wireMockServer = new WireMockServer(8090);
     private AccessDAO accessDAO;
-    private CryptoDatabaseFactory cryptoFactory;
     private DeviceManagementService deviceManagementService;
 
     // Consts
@@ -79,7 +78,7 @@ public class DeviceManagementServiceTest {
         stubFor(get(urlEqualTo("/api-version"))
             .willReturn(okJson(apiVersionV6)));
 
-        cryptoFactory = mock(CryptoDatabaseFactory.class);
+        CryptoDatabaseFactory cryptoFactory = mock(CryptoDatabaseFactory.class);
         when(cryptoFactory.create(userId)).thenReturn(mockedCrypto);
         accessDAO = mock(AccessDAO.class);
 
@@ -109,6 +108,8 @@ public class DeviceManagementServiceTest {
         ).thenReturn(1);
         stubFor(get(urlEqualTo("/v6/feature-configs"))
             .willReturn(okJson(disabledMlsFeatureConfigJsonResponse)));
+        stubFor(post(urlEqualTo("/v6/access?client_id=" + clientId))
+            .willReturn(okJson(accessResponse)));
 
         // when
         deviceManagementService.confirmDevice(userId, teamId, clientId, refreshToken);
@@ -188,6 +189,8 @@ public class DeviceManagementServiceTest {
             .willReturn(okJson(enabledMlsFeatureConfigJsonResponse)));
         stubFor(get(urlEqualTo("/v6/mls/public-keys"))
             .willReturn(okJson(mlsPublicKeysSuccessResponse)));
+        stubFor(post(urlEqualTo("/v6/access?client_id=" + clientId))
+            .willReturn(okJson(accessResponse)));
         stubFor(put(urlEqualTo("/v6/clients/" + clientId))
             .willReturn(jsonResponse("{\"error\":\"error from clients/" + clientId + "\"}", 400)));
 
@@ -196,7 +199,7 @@ public class DeviceManagementServiceTest {
             deviceManagementService.confirmDevice(userId, teamId, clientId, refreshToken);
         } catch (Exception exception) {
             // then
-            assert exception.getMessage().equals("ExecutionException: {\"error\":\"error from clients/" + clientId + "\"}");
+            assert exception.getMessage().equals("{\"error\":\"error from clients/" + clientId + "\"}");
         }
 
         // then
@@ -355,6 +358,8 @@ public class DeviceManagementServiceTest {
         QualifiedId conversationId = new QualifiedId(UUID.randomUUID(), MetadataDAO.FALLBACK_DOMAIN_KEY);
         String clientId = UUID.randomUUID().toString();
 
+        stubFor(post(urlEqualTo("/v6/access?client_id=" + clientId))
+            .willReturn(okJson(accessResponse)));
         stubFor(get(urlEqualTo("/v6/feature-configs"))
             .willReturn(okJson(enabledMlsFeatureConfigJsonResponse)));
         stubFor(get(urlEqualTo("/v6/mls/public-keys"))
@@ -385,6 +390,8 @@ public class DeviceManagementServiceTest {
         QualifiedId conversationId = new QualifiedId(UUID.randomUUID(), MetadataDAO.FALLBACK_DOMAIN_KEY);
         String clientId = UUID.randomUUID().toString();
 
+        stubFor(post(urlEqualTo("/v6/access?client_id=" + clientId))
+            .willReturn(okJson(accessResponse)));
         stubFor(get(urlEqualTo("/v6/feature-configs"))
             .willReturn(okJson(enabledMlsFeatureConfigJsonResponse)));
         stubFor(get(urlEqualTo("/v6/mls/public-keys"))
@@ -425,6 +432,8 @@ public class DeviceManagementServiceTest {
 
         stubFor(get(urlEqualTo("/v6/feature-configs"))
             .willReturn(okJson(enabledMlsFeatureConfigJsonResponse)));
+        stubFor(post(urlEqualTo("/v6/access?client_id=" + clientId))
+            .willReturn(okJson(accessResponse)));
         stubFor(get(urlEqualTo("/v6/mls/public-keys"))
             .willReturn(okJson(mlsPublicKeysSuccessResponse)));
         stubFor(put(urlEqualTo("/v6/clients/" + clientId))
@@ -484,7 +493,7 @@ public class DeviceManagementServiceTest {
     public void givenKnownUser_whenRemovingDeviceAndMlsIsDisabled_thenNoWipeIsCalled() throws IOException, CryptoException {
         // given
         Path path = Paths.get("mls/" + clientId);
-        try (CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(clientId, coreCryptoPassword)) {
+        try (CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(clientId, userId, coreCryptoPassword)) {
             assert cryptoMlsClient != null;
             assert Files.exists(path);
         }
@@ -518,7 +527,7 @@ public class DeviceManagementServiceTest {
             .willReturn(okJson(mlsPublicKeysSuccessResponse)));
 
         Path path = Paths.get("mls/" + clientId);
-        try (CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(clientId, coreCryptoPassword)) {
+        try (CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(clientId, userId, coreCryptoPassword)) {
             assert cryptoMlsClient != null;
             assert Files.exists(path);
         }
@@ -633,6 +642,15 @@ public class DeviceManagementServiceTest {
           "domain": "example.com",
           "federation": false,
           "supported": [6]
+        }
+    """;
+
+    private static final String accessResponse = """
+        {
+          "access_token": "string",
+          "expires_in": 0,
+          "token_type": "Bearer",
+          "user": "99db9768-04e3-4b5d-9268-831b6a25c4ab"
         }
     """;
 


### PR DESCRIPTION
* Publish MLS public key before key packages
* Refactoring refreshing token
* Bump to 1.2.1

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Could not publish key packages or join MLS conversations

### Causes (Optional)

Unknown configs, like using client when refreshing tokens and initializing MLS clients with client + userId + domain

### Solutions

Import new Xenon, Helium and adapt on them

#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
