### PR TITLE
feat(use any mls ciphersuite, add mls support on established client) #WPB-14877

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wire.bots</groupId>
     <artifactId>hold</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
 
     <name>Legal Hold</name>
     <description>Legal Hold Service For Wire</description>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.wire</groupId>
             <artifactId>helium</artifactId>
-            <version>1.6.0</version>
+            <version>1.6.1</version>
         </dependency>
         <dependency>
             <groupId>com.github.smoketurner</groupId>

--- a/src/main/java/com/wire/bots/hold/DAO/AccessDAO.java
+++ b/src/main/java/com/wire/bots/hold/DAO/AccessDAO.java
@@ -10,14 +10,16 @@ import java.util.List;
 import java.util.UUID;
 
 public interface AccessDAO {
-    @SqlUpdate("INSERT INTO Access (userId, userDomain, clientId, cookie, updated, created, enabled) " +
-            "VALUES (:userId, :userDomain, :clientId, :cookie, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1) " +
+    @SqlUpdate("INSERT INTO Access (userId, userDomain, clientId, cookie, mlsClientCreated, mlsCiphersuite, updated, created, enabled) " +
+            "VALUES (:userId, :userDomain, :clientId, :cookie, :mlsClientCreated, :mlsCiphersuite, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1) " +
             "ON CONFLICT (userId, userDomain) DO UPDATE SET cookie = EXCLUDED.cookie, clientId = EXCLUDED.clientId, " +
-            "updated = EXCLUDED.updated, enabled = EXCLUDED.enabled")
+            "updated = EXCLUDED.updated, enabled = EXCLUDED.enabled, mlsClientCreated = EXCLUDED.mlsClientCreated, mlsCiphersuite = EXCLUDED.mlsCiphersuite")
     int insert(@Bind("userId") UUID userId,
                @Bind("userDomain") String userDomain,
                @Bind("clientId") String clientId,
-               @Bind("cookie") String cookie);
+               @Bind("cookie") String cookie,
+               @Bind("mlsClientCreated") Boolean mlsClientCreated,
+               @Bind("mlsCiphersuite") Integer mlsCiphersuite);
 
     @SqlUpdate("UPDATE Access SET enabled = 0, updated = CURRENT_TIMESTAMP WHERE userId = :userId " +
         "AND (( :userDomain IS NULL AND userDomain IS null ) or ( :userDomain IS NOT NULL AND userDomain = :userDomain ))")

--- a/src/main/java/com/wire/bots/hold/DAO/AccessResultSetMapper.java
+++ b/src/main/java/com/wire/bots/hold/DAO/AccessResultSetMapper.java
@@ -20,6 +20,8 @@ public class AccessResultSetMapper implements ColumnMapper<LHAccess> {
         LHAccess.clientId = rs.getString("clientId");
         LHAccess.token = rs.getString("token");
         LHAccess.cookie = rs.getString("cookie");
+        LHAccess.mlsClientCreated = rs.getBoolean("mlsClientCreated");
+        LHAccess.mlsCiphersuite = rs.getInt("mlsCiphersuite");
         LHAccess.updated = rs.getString("updated");
         LHAccess.created = rs.getString("created");
         LHAccess.enabled = rs.getInt("enabled") == 1;

--- a/src/main/java/com/wire/bots/hold/NotificationProcessor.java
+++ b/src/main/java/com/wire/bots/hold/NotificationProcessor.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wire.bots.hold.DAO.AccessDAO;
 import com.wire.bots.hold.model.database.LHAccess;
+import com.wire.bots.hold.service.DeviceManagementService;
 import com.wire.bots.hold.utils.LoginClientExtension;
 import com.wire.helium.API;
 import com.wire.helium.models.Access;
@@ -26,11 +27,18 @@ public class NotificationProcessor implements Runnable {
     private final Client client;
     private final AccessDAO accessDAO;
     private final HoldMessageResource messageResource;
+    private final DeviceManagementService deviceManagementService;
 
-    NotificationProcessor(Client client, AccessDAO accessDAO, HoldMessageResource messageResource) {
+    NotificationProcessor(
+        Client client,
+        AccessDAO accessDAO,
+        HoldMessageResource messageResource,
+        DeviceManagementService deviceManagementService)
+    {
         this.client = client;
         this.accessDAO = accessDAO;
         this.messageResource = messageResource;
+        this.deviceManagementService = deviceManagementService;
     }
 
     @Override
@@ -53,8 +61,12 @@ public class NotificationProcessor implements Runnable {
 
             final Access access = LoginClientExtension.refreshToken(client, device.clientId, device.cookie);
             accessDAO.update(device.userId.id, device.userId.domain, access.getAccessToken(), access.getCookie().value);
-
             final API api = new API(client, null, access.getAccessToken());
+
+            if (!device.mlsClientCreated) {
+                deviceManagementService.configureMlsClient(device.userId, device.clientId, access.getCookie().value, api);
+            }
+
             NotificationList notificationList = api.retrieveNotifications(
                 device.clientId,
                 device.last,

--- a/src/main/java/com/wire/bots/hold/Service.java
+++ b/src/main/java/com/wire/bots/hold/Service.java
@@ -84,7 +84,7 @@ public class Service extends Application<Config> {
     @Override
     public void initialize(Bootstrap<Config> bootstrap) {
         bootstrap.setConfigurationSourceProvider(new SubstitutingSourceProvider(
-                bootstrap.getConfigurationSourceProvider(), new EnvironmentVariableSubstitutor(false)));
+            bootstrap.getConfigurationSourceProvider(), new EnvironmentVariableSubstitutor(false)));
 
         bootstrap.addBundle(new SwaggerBundle<>() {
             @Override
@@ -173,12 +173,12 @@ public class Service extends Application<Config> {
         final HoldClientRepo repo = new HoldClientRepo(jdbi, cf, httpClient, config.coreCryptoPassword);
 
         final HoldMessageResource holdMessageResource = new HoldMessageResource(new MessageHandler(jdbi), repo);
-        final NotificationProcessor notificationProcessor = new NotificationProcessor(httpClient, accessDAO, holdMessageResource);
+        final NotificationProcessor notificationProcessor = new NotificationProcessor(httpClient, accessDAO, holdMessageResource, deviceManagementService);
 
         environment.lifecycle()
-                .scheduledExecutorService("notifications")
-                .build()
-                .scheduleWithFixedDelay(notificationProcessor, 10, config.sleep.toSeconds(), TimeUnit.SECONDS);
+            .scheduledExecutorService("notifications")
+            .build()
+            .scheduleWithFixedDelay(notificationProcessor, 10, config.sleep.toSeconds(), TimeUnit.SECONDS);
 
         CollectorRegistry.defaultRegistry.register(new DropwizardExports(metrics));
 
@@ -199,24 +199,24 @@ public class Service extends Application<Config> {
 
     private Client createHttpClient(Config config, Environment env) {
         return new JerseyClientBuilder(env)
-                .using(config.getJerseyClient())
-                .withProvider(MultiPartFeature.class)
-                .withProvider(JacksonJsonProvider.class)
-                .build(getName());
+            .using(config.getJerseyClient())
+            .withProvider(MultiPartFeature.class)
+            .withProvider(JacksonJsonProvider.class)
+            .build(getName());
     }
 
     protected Jdbi buildJdbi(Config.Database database, Environment env) {
         return Jdbi
-                .create(database.build(env.metrics(), getName()))
-                .installPlugin(new SqlObjectPlugin());
+            .create(database.build(env.metrics(), getName()))
+            .installPlugin(new SqlObjectPlugin());
     }
 
     protected void setupDatabase(Config.Database database) {
         Flyway flyway = Flyway
-                .configure()
-                .dataSource(database.getUrl(), database.getUser(), database.getPassword())
-                .baselineOnMigrate(database.baseline)
-                .load();
+            .configure()
+            .dataSource(database.getUrl(), database.getUser(), database.getPassword())
+            .baselineOnMigrate(database.baseline)
+            .load();
         flyway.migrate();
     }
 

--- a/src/main/java/com/wire/bots/hold/model/database/LHAccess.java
+++ b/src/main/java/com/wire/bots/hold/model/database/LHAccess.java
@@ -10,6 +10,8 @@ public class LHAccess {
     public String clientId;
     public String token;
     public String cookie;
+    public boolean mlsClientCreated;
+    public Integer mlsCiphersuite;
     public String updated;
     public String created;
     public boolean enabled;

--- a/src/main/java/com/wire/bots/hold/resource/v0/backend/ConfirmResourceV0.java
+++ b/src/main/java/com/wire/bots/hold/resource/v0/backend/ConfirmResourceV0.java
@@ -36,7 +36,6 @@ public class ConfirmResourceV0 {
         try {
             deviceManagementService.confirmDevice(
                 new QualifiedId(payload.userId, null),
-                payload.teamId,
                 payload.clientId,
                 payload.refreshToken
             );

--- a/src/main/java/com/wire/bots/hold/resource/v0/backend/RemoveResourceV0.java
+++ b/src/main/java/com/wire/bots/hold/resource/v0/backend/RemoveResourceV0.java
@@ -34,8 +34,7 @@ public class RemoveResourceV0 {
     public Response remove(@ApiParam @Valid InitPayloadV0 payload) {
         try {
             deviceManagementService.removeDevice(
-                new QualifiedId(payload.userId, null),
-                payload.teamId
+                new QualifiedId(payload.userId, null)
             );
 
             return Response.

--- a/src/main/java/com/wire/bots/hold/resource/v1/backend/ConfirmResourceV1.java
+++ b/src/main/java/com/wire/bots/hold/resource/v1/backend/ConfirmResourceV1.java
@@ -35,7 +35,6 @@ public class ConfirmResourceV1 {
         try {
             deviceManagementService.confirmDevice(
                 payload.userId,
-                payload.teamId,
                 payload.clientId,
                 payload.refreshToken
             );

--- a/src/main/java/com/wire/bots/hold/resource/v1/backend/RemoveResourceV1.java
+++ b/src/main/java/com/wire/bots/hold/resource/v1/backend/RemoveResourceV1.java
@@ -32,7 +32,7 @@ public class RemoveResourceV1 {
         @ApiResponse(code = 200, message = "Legal Hold Device was removed")})
     public Response remove(@ApiParam @Valid InitPayloadV1 payload) {
         try {
-            deviceManagementService.removeDevice(payload.userId, payload.teamId);
+            deviceManagementService.removeDevice(payload.userId);
 
             return Response
                 .ok()

--- a/src/main/java/com/wire/bots/hold/service/DeviceManagementService.java
+++ b/src/main/java/com/wire/bots/hold/service/DeviceManagementService.java
@@ -10,6 +10,7 @@ import com.wire.helium.API;
 import com.wire.helium.models.Access;
 import com.wire.xenon.WireClientBase;
 import com.wire.xenon.backend.models.Conversation;
+import com.wire.xenon.backend.models.FeatureConfig;
 import com.wire.xenon.backend.models.QualifiedId;
 import com.wire.xenon.crypto.Crypto;
 import com.wire.xenon.crypto.mls.CryptoMlsClient;
@@ -74,7 +75,24 @@ public class DeviceManagementService {
     }
 
     /**
-     * <p>Confirm a user's device under legal hold.</p>
+     * Confirm a user's device under legal hold. Client authentication performed using refreshToken.
+     * @param userId user setup to be put under legal hold
+     * @param clientId user's device
+     * @param refreshToken cookie token from the database, used to get new access token and cookie
+     * @throws RuntimeException when any of the (parallel or not) MLS tasks fails. Or if inserting refreshToken to Database fails.
+     */
+    public void confirmDevice(QualifiedId userId, String clientId, String refreshToken) throws RuntimeException {
+        final Access access = LoginClientExtension.refreshToken(client, clientId, refreshToken);
+        API api = new API(client, null, access.accessToken);
+        boolean mlsClientCreated = configureMlsClient(userId, clientId, access.getCookie().value, api);
+
+        if (!mlsClientCreated) {
+            // If MLS client was added storing the client with MLS data is done already, else store only Proteus data
+            storeProteusOnlyDevice(userId, clientId, access.getCookie().value);
+        }
+    }
+    /**
+     * Confirm a user's device under legal hold. Client authentication is done beforehand
      * <p>
      *     If MLS is enabled, then we initialize CryptoMlsClient and WireClientBase, then fetch and upload in parallel:
      *      - PublicKeys
@@ -87,17 +105,18 @@ public class DeviceManagementService {
      *     Stores the refreshToken in order to fetch user notifications while under legal hold
      * </p>
      * @param userId user setup to be put under legal hold
-     * @param teamId user's own team
      * @param clientId user's device
-     * @param refreshToken token used to get expiring api tokens
+     * @param cookie new cookie token used to get access tokens
+     * @param api object to interact with Wire API, setup for the client with a valid access token
      * @throws RuntimeException when any of the (parallel or not) MLS tasks fails. Or if inserting refreshToken to Database fails.
+     * @return true if MLS client was added, false otherwise
      */
-    public void confirmDevice(QualifiedId userId, UUID teamId, String clientId, String refreshToken) throws RuntimeException {
-        final Access access = LoginClientExtension.refreshToken(client, clientId, refreshToken);
-        API api = new API(client, null, access.accessToken);
+    public boolean configureMlsClient(QualifiedId userId, String clientId, String cookie, API api) throws RuntimeException {
+        final FeatureConfig mlsConfig = api.getFeatureConfig();
 
-        if (api.isMlsEnabled()) {
-            try (CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(clientId, userId, coreCryptoPassword)) {
+        if (mlsConfig.mls.isMlsStatusEnabled()) {
+            Logger.info("MLS is enabled for user %s, configuring client and joining conversations", userId);
+            try (CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(clientId, userId, mlsConfig.mls.config.defaultCipherSuite, coreCryptoPassword)) {
                 // CryptoMlsClient will be closed from `try` with resource so there is no issue passing
                 // Crypto as null, as we will not be calling wireClientBase.close()
                 WireClientBase wireClientBase = new WireClientBase(api, null, cryptoMlsClient, null);
@@ -133,47 +152,54 @@ public class DeviceManagementService {
                     Logger.info("Conversation ID: %s, Name: %s, GroupId: %s", conversation.id, conversation.name, conversation.mlsGroupId);
                     wireClientBase.joinMlsConversation(conversation.id, conversation.mlsGroupId);
                 }
+                storeProteusAndMlsDevice(userId, clientId, cookie, mlsConfig.mls.config.defaultCipherSuite);
+                return true;
             } catch (ExecutionException exception) {
                 throw new RuntimeException("ExecutionException: " + exception.getCause().getMessage());
             } catch (InterruptedException exception) {
                 throw new RuntimeException("InterruptedException: " + exception.getMessage());
             }
         }
+        return false;
+    }
 
-        // Proteus
+    private void storeProteusAndMlsDevice(QualifiedId userId, String clientId, String cookie, Integer mlsCiphersuite) {
+        storeDevice(userId, clientId, cookie, true, mlsCiphersuite);
+    }
+
+    private void storeProteusOnlyDevice(QualifiedId userId, String clientId, String cookie) {
+        storeDevice(userId, clientId, cookie, false, null);
+    }
+
+    private void storeDevice(QualifiedId userId, String clientId, String cookie, Boolean mlsClientAdded, Integer mlsCiphersuite) {
         int insert = accessDAO.insert(userId.id,
             userId.domain,
             clientId,
-            access.getCookie().value);
+            cookie,
+            mlsClientAdded,
+            mlsCiphersuite);
 
         if (0 == insert) {
-            Logger.error("ConfirmResource: Failed to insert Access %s:%s",
-                userId,
-                clientId);
-
+            Logger.error("ConfirmResource: Failed to insert Access %s:%s", userId, clientId);
             throw new RuntimeException("Cannot insert new device");
         }
 
-        Logger.info("ConfirmResource: team: %s, user:%s, client: %s",
-            teamId,
-            userId,
-            clientId);
+        Logger.info("ConfirmResource: user:%s, client: %s", userId, clientId);
     }
 
     /**
      * Remove a user from legal hold.
+     * <p>Before soft-deleting on the database, cleans up Proteus data and MLS data if it was ever created</p>
      * @param userId user setup to be put under legal hold
-     * @param teamId user's own team
      * @throws IOException
      * @throws CryptoException
      */
-    public void removeDevice(QualifiedId userId, UUID teamId) throws IOException, CryptoException {
+    public void removeDevice(QualifiedId userId) throws IOException, CryptoException {
         // MLS
         LHAccess userAccess = accessDAO.get(userId.id, userId.domain);
         if (userAccess != null) {
-            API api = new API(client, null, userAccess.token);
-            if (api.isMlsEnabled()) {
-                try (CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(userAccess.clientId, userId, coreCryptoPassword)) {
+            if (userAccess.mlsClientCreated) {
+                try (CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(userAccess.clientId, userId, userAccess.mlsCiphersuite, coreCryptoPassword)) {
                     cryptoMlsClient.wipe();
                 }
             }
@@ -182,18 +208,12 @@ public class DeviceManagementService {
         // Proteus
         try (Crypto crypto = cf.create(userId)) {
             crypto.purge();
-
-            int removeAccess = accessDAO.disable(userId.id, userId.domain);
-
-            Logger.info(
-                "RemoveResource: team: %s, user: %s, removed: %s",
-                teamId,
-                userId,
-                removeAccess
-            );
         } catch (Exception e) {
             Logger.exception(e, "RemoveLegalHoldDevice: %s", e.getMessage());
             throw e;
         }
+
+        int removeAccess = accessDAO.disable(userId.id, userId.domain);
+        Logger.info("RemoveResource: user: %s, removed: %s", userId, removeAccess);
     }
 }

--- a/src/main/java/com/wire/bots/hold/service/DeviceManagementService.java
+++ b/src/main/java/com/wire/bots/hold/service/DeviceManagementService.java
@@ -91,6 +91,7 @@ public class DeviceManagementService {
             storeProteusOnlyDevice(userId, clientId, access.getCookie().value);
         }
     }
+
     /**
      * Confirm a user's device under legal hold. Client authentication is done beforehand
      * <p>

--- a/src/main/java/com/wire/bots/hold/utils/HoldClientRepo.java
+++ b/src/main/java/com/wire/bots/hold/utils/HoldClientRepo.java
@@ -31,8 +31,8 @@ public class HoldClientRepo {
         final LHAccess single = jdbi.onDemand(AccessDAO.class).get(userId.id, userId.domain);
         final API api = new API(httpClient, conversationId, single.token);
 
-        // for receiving notifications
-        final CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(deviceId, userId, coreCryptoPassword);
+        // Create MLS client only if device was already initialized for MLS
+        final CryptoMlsClient cryptoMlsClient = single.mlsClientCreated ? new CryptoMlsClient(deviceId, userId, single.mlsCiphersuite, coreCryptoPassword) : null;
         return new HoldWireClient(userId, deviceId, conversationId, cryptoMlsClient, crypto, api);
     }
 }

--- a/src/main/resources/db/migration/V109__add_mls_migrated_and_ciphersuite_column_in_access.sql
+++ b/src/main/resources/db/migration/V109__add_mls_migrated_and_ciphersuite_column_in_access.sql
@@ -1,0 +1,5 @@
+ALTER TABLE Access
+ADD COLUMN mlsClientCreated BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE Access
+ADD COLUMN mlsCiphersuite SMALLINT DEFAULT null;

--- a/src/test/java/com/wire/bots/hold/DatabaseTest.java
+++ b/src/test/java/com/wire/bots/hold/DatabaseTest.java
@@ -19,6 +19,8 @@ import org.junit.Test;
 
 import java.util.*;
 
+import static com.wire.bots.hold.utils.Constant.DEFAULT_CIPHERSUITE_IDENTIFIER;
+
 public class DatabaseTest {
     private static final DropwizardTestSupport<Config> SUPPORT = new DropwizardTestSupport<>(
         Service.class, "hold.yaml",
@@ -104,7 +106,7 @@ public class DatabaseTest {
         final String cookie2 = "cookie2";
         final String token = "token";
 
-        final int insert = accessDAO.insert(userId.id, userId.domain, clientId, cookie);
+        final int insert = accessDAO.insert(userId.id, userId.domain, clientId, cookie, false, null);
         accessDAO.updateLast(userId.id, userId.domain, last);
         accessDAO.update(userId.id, userId.domain, token, cookie2);
 
@@ -114,10 +116,12 @@ public class DatabaseTest {
 
         accessDAO.disable(userId.id, userId.domain);
 
-        final int insert2 = accessDAO.insert(userId.id, userId.domain, clientId, cookie);
+        final int insert2 = accessDAO.insert(userId.id, userId.domain, clientId, cookie, true, DEFAULT_CIPHERSUITE_IDENTIFIER);
         final LHAccess lhAccess2 = accessDAO.get(userId.id, userId.domain);
         assert lhAccess2 != null;
         assert lhAccess2.created.equals(lhAccess.created);
+        assert lhAccess2.mlsClientCreated;
+        assert lhAccess2.mlsCiphersuite.equals(DEFAULT_CIPHERSUITE_IDENTIFIER);
     }
 
     @Test

--- a/src/test/java/com/wire/bots/hold/resource/v0/audit/ConversationResourceTest.java
+++ b/src/test/java/com/wire/bots/hold/resource/v0/audit/ConversationResourceTest.java
@@ -16,7 +16,10 @@ import com.wire.xenon.models.TextMessage;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.DropwizardTestSupport;
 import org.apache.http.HttpStatus;
-import org.junit.*;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.HttpHeaders;
@@ -27,6 +30,8 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
+
+import static com.wire.bots.hold.utils.Constant.DEFAULT_CIPHERSUITE_IDENTIFIER;
 
 public class ConversationResourceTest {
     private static final String TOKEN = "dummy_token";
@@ -182,7 +187,9 @@ public class ConversationResourceTest {
             userId.id,
             userId.domain,
             USER_CLIENT_ID,
-            USER_COOKIE
+            USER_COOKIE,
+            true,
+            DEFAULT_CIPHERSUITE_IDENTIFIER
         );
         accessDAO.update(
             userId.id,

--- a/src/test/java/com/wire/bots/hold/service/DeviceManagementServiceTest.java
+++ b/src/test/java/com/wire/bots/hold/service/DeviceManagementServiceTest.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.UUID;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.wire.bots.hold.utils.Constant.DEFAULT_CIPHERSUITE_IDENTIFIER;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.*;
 
@@ -51,7 +52,6 @@ public class DeviceManagementServiceTest {
 
     // Consts
     private static final QualifiedId userId = new QualifiedId(UUID.randomUUID(), MetadataDAO.FALLBACK_DOMAIN_KEY);
-    private static final UUID teamId = UUID.randomUUID();
     private static final String clientId = UUID.randomUUID().toString();
     private static final String refreshToken = UUID.randomUUID().toString();
     private static final String coreCryptoPassword = "secr3t";
@@ -103,7 +103,9 @@ public class DeviceManagementServiceTest {
                 userId.id,
                 userId.domain,
                 clientId,
-                refreshToken
+                refreshToken,
+                false,
+                null
             )
         ).thenReturn(1);
         stubFor(get(urlEqualTo("/v6/feature-configs"))
@@ -112,14 +114,16 @@ public class DeviceManagementServiceTest {
             .willReturn(okJson(accessResponse)));
 
         // when
-        deviceManagementService.confirmDevice(userId, teamId, clientId, refreshToken);
+        deviceManagementService.confirmDevice(userId, clientId, refreshToken);
 
         // then
         verify(accessDAO, times(1)).insert(
             userId.id,
             userId.domain,
             clientId,
-            refreshToken
+            refreshToken,
+            false,
+            null
         );
     }
 
@@ -131,7 +135,9 @@ public class DeviceManagementServiceTest {
                 userId.id,
                 userId.domain,
                 clientId,
-                refreshToken
+                refreshToken,
+                false,
+                null
             )
         ).thenReturn(0);
         stubFor(get(urlEqualTo("/v6/feature-configs"))
@@ -139,7 +145,7 @@ public class DeviceManagementServiceTest {
 
         // when
         try {
-            deviceManagementService.confirmDevice(userId, teamId, clientId, refreshToken);
+            deviceManagementService.confirmDevice(userId, clientId, refreshToken);
         } catch (Exception exception) {
             // then
             assert exception.getMessage().equals("Cannot insert new device");
@@ -150,7 +156,9 @@ public class DeviceManagementServiceTest {
             userId.id,
             userId.domain,
             clientId,
-            refreshToken
+            refreshToken,
+            false,
+            null
         );
     }
 
@@ -166,19 +174,23 @@ public class DeviceManagementServiceTest {
                 userId.id,
                 userId.domain,
                 clientId,
-                refreshToken
+                refreshToken,
+                false,
+                null
             )
         ).thenReturn(1);
 
         // when
-        deviceManagementService.confirmDevice(userId, teamId, clientId, refreshToken);
+        deviceManagementService.confirmDevice(userId, clientId, refreshToken);
 
         // then
         verify(accessDAO, times(1)).insert(
             userId.id,
             userId.domain,
             clientId,
-            refreshToken
+            refreshToken,
+            false,
+            null
         );
     }
 
@@ -196,7 +208,7 @@ public class DeviceManagementServiceTest {
 
         // when
         try {
-            deviceManagementService.confirmDevice(userId, teamId, clientId, refreshToken);
+            deviceManagementService.confirmDevice(userId, clientId, refreshToken);
         } catch (Exception exception) {
             // then
             assert exception.getMessage().equals("{\"error\":\"error from clients/" + clientId + "\"}");
@@ -207,7 +219,9 @@ public class DeviceManagementServiceTest {
             userId.id,
             userId.domain,
             clientId,
-            refreshToken
+            refreshToken,
+            true,
+            DEFAULT_CIPHERSUITE_IDENTIFIER
         );
     }
 
@@ -225,7 +239,7 @@ public class DeviceManagementServiceTest {
 
         // when
         try {
-            deviceManagementService.confirmDevice(userId, teamId, clientId, refreshToken);
+            deviceManagementService.confirmDevice(userId, clientId, refreshToken);
         } catch (Exception exception) {
             // then
             assert exception.getMessage().equals("ExecutionException: {\"error\":\"error from mls/key-packages/self/" + clientId + "\"}");
@@ -236,7 +250,9 @@ public class DeviceManagementServiceTest {
             userId.id,
             userId.domain,
             clientId,
-            refreshToken
+            refreshToken,
+            true,
+            DEFAULT_CIPHERSUITE_IDENTIFIER
         );
     }
 
@@ -258,19 +274,23 @@ public class DeviceManagementServiceTest {
                 userId.id,
                 userId.domain,
                 clientId,
-                refreshToken
+                refreshToken,
+                true,
+                DEFAULT_CIPHERSUITE_IDENTIFIER
             )
         ).thenReturn(1);
 
         // when
-        deviceManagementService.confirmDevice(userId, teamId, clientId, refreshToken);
+        deviceManagementService.confirmDevice(userId, clientId, refreshToken);
 
         // then
         verify(accessDAO, times(1)).insert(
             userId.id,
             userId.domain,
             clientId,
-            refreshToken
+            refreshToken,
+            true,
+            DEFAULT_CIPHERSUITE_IDENTIFIER
         );
     }
 
@@ -297,19 +317,23 @@ public class DeviceManagementServiceTest {
                 userId.id,
                 userId.domain,
                 clientId,
-                refreshToken
+                refreshToken,
+                true,
+                DEFAULT_CIPHERSUITE_IDENTIFIER
             )
         ).thenReturn(1);
 
         // when
-        deviceManagementService.confirmDevice(userId, teamId, clientId, refreshToken);
+        deviceManagementService.confirmDevice(userId, clientId, refreshToken);
 
         // then
         verify(accessDAO, times(1)).insert(
             userId.id,
             userId.domain,
             clientId,
-            refreshToken
+            refreshToken,
+            true,
+            DEFAULT_CIPHERSUITE_IDENTIFIER
         );
     }
 
@@ -336,19 +360,23 @@ public class DeviceManagementServiceTest {
                 userId.id,
                 userId.domain,
                 clientId,
-                refreshToken
+                refreshToken,
+                true,
+                DEFAULT_CIPHERSUITE_IDENTIFIER
             )
         ).thenReturn(1);
 
         // when
-        deviceManagementService.confirmDevice(userId, teamId, clientId, refreshToken);
+        deviceManagementService.confirmDevice(userId, clientId, refreshToken);
 
         // then
         verify(accessDAO, times(1)).insert(
             userId.id,
             userId.domain,
             clientId,
-            refreshToken
+            refreshToken,
+            true,
+            DEFAULT_CIPHERSUITE_IDENTIFIER
         );
     }
 
@@ -377,7 +405,7 @@ public class DeviceManagementServiceTest {
 
         // when
         try {
-            deviceManagementService.confirmDevice(userId, teamId, clientId, refreshToken);
+            deviceManagementService.confirmDevice(userId, clientId, refreshToken);
         } catch (Exception exception) {
             // then
             assert exception.getMessage().equals("{\"error\":\"error from conversations/" + conversationId.domain + "/" + conversationId.id + "/groupinfo\"}");
@@ -418,7 +446,7 @@ public class DeviceManagementServiceTest {
 
         // when
         try {
-            deviceManagementService.confirmDevice(userId, teamId, clientId, refreshToken);
+            deviceManagementService.confirmDevice(userId, clientId, refreshToken);
         } catch (Exception exception) {
             // then
             assert exception.getMessage().equals("{\"error\":\"error from mls/commit-bundles\"}");
@@ -461,19 +489,23 @@ public class DeviceManagementServiceTest {
                 userId.id,
                 userId.domain,
                 clientId,
-                refreshToken
+                refreshToken,
+                true,
+                DEFAULT_CIPHERSUITE_IDENTIFIER
             )
         ).thenReturn(1);
 
         // when
-        deviceManagementService.confirmDevice(userId, teamId, clientId, refreshToken);
+        deviceManagementService.confirmDevice(userId, clientId, refreshToken);
 
         // then
         verify(accessDAO, times(1)).insert(
             userId.id,
             userId.domain,
             clientId,
-            refreshToken
+            refreshToken,
+            true,
+            DEFAULT_CIPHERSUITE_IDENTIFIER
         );
     }
 
@@ -483,17 +515,17 @@ public class DeviceManagementServiceTest {
         when(accessDAO.get(userId.id, userId.domain)).thenReturn(null);
 
         // when
-        deviceManagementService.removeDevice(userId, teamId);
+        deviceManagementService.removeDevice(userId);
 
         // then
         verify(accessDAO, times(1)).get(userId.id, userId.domain);
     }
 
     @Test
-    public void givenKnownUser_whenRemovingDeviceAndMlsIsDisabled_thenNoWipeIsCalled() throws IOException, CryptoException {
+    public void givenKnownUser_whenRemovingDeviceAndMlsIsDisabled_thenWipeIsCalled() throws IOException, CryptoException {
         // given
         Path path = Paths.get("mls/" + clientId);
-        try (CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(clientId, userId, coreCryptoPassword)) {
+        try (CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(clientId, userId, DEFAULT_CIPHERSUITE_IDENTIFIER, coreCryptoPassword)) {
             assert cryptoMlsClient != null;
             assert Files.exists(path);
         }
@@ -504,33 +536,25 @@ public class DeviceManagementServiceTest {
         lhAccess.clientId = clientId;
         lhAccess.token = refreshToken;
         lhAccess.cookie = "cookie";
+        lhAccess.mlsClientCreated = true;
+        lhAccess.mlsCiphersuite = DEFAULT_CIPHERSUITE_IDENTIFIER;
         lhAccess.enabled = true;
 
         when(accessDAO.get(userId.id, userId.domain)).thenReturn(lhAccess);
-        stubFor(get(urlEqualTo("/v6/feature-configs"))
-            .willReturn(okJson(disabledMlsFeatureConfigJsonResponse)));
 
         // when
-        deviceManagementService.removeDevice(userId, teamId);
+        deviceManagementService.removeDevice(userId);
 
         // then
         verify(accessDAO, times(1)).get(userId.id, userId.domain);
-        assert Files.exists(path);
+        assert Files.notExists(path);
     }
 
     @Test
-    public void givenKnownUser_whenRemovingDeviceAndMlsIsEnabled_thenWipeIsCalled() throws IOException, CryptoException {
-        // given
-        stubFor(get(urlEqualTo("/v6/feature-configs"))
-            .willReturn(okJson(enabledMlsFeatureConfigJsonResponse)));
-        stubFor(get(urlEqualTo("/v6/mls/public-keys"))
-            .willReturn(okJson(mlsPublicKeysSuccessResponse)));
-
+    public void givenKnownUser_whenRemovingDeviceAndMlsWasNotCreated_thenNoMlsFilesExist() throws IOException, CryptoException {
+        String clientId = UUID.randomUUID().toString();
         Path path = Paths.get("mls/" + clientId);
-        try (CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(clientId, userId, coreCryptoPassword)) {
-            assert cryptoMlsClient != null;
-            assert Files.exists(path);
-        }
+        assert Files.notExists(path);
 
         LHAccess lhAccess = new LHAccess();
         lhAccess.last = UUID.randomUUID();
@@ -538,12 +562,14 @@ public class DeviceManagementServiceTest {
         lhAccess.clientId = clientId;
         lhAccess.token = refreshToken;
         lhAccess.cookie = "cookie";
+        lhAccess.mlsClientCreated = false;
+        lhAccess.mlsCiphersuite = null;
         lhAccess.enabled = true;
 
         when(accessDAO.get(userId.id, userId.domain)).thenReturn(lhAccess);
 
         // when
-        deviceManagementService.removeDevice(userId, teamId);
+        deviceManagementService.removeDevice(userId);
 
         // then
         verify(accessDAO, times(1)).get(userId.id, userId.domain);
@@ -606,8 +632,8 @@ public class DeviceManagementServiceTest {
         {
             "mls": {
                 "config": {
-                  "allowedCipherSuites": [65535],
-                  "defaultCipherSuite": 65535,
+                  "allowedCipherSuites": [1],
+                  "defaultCipherSuite": 1,
                   "defaultProtocol": "proteus",
                   "protocolToggleUsers": [],
                   "supportedProtocols": ["proteus"]
@@ -694,7 +720,7 @@ public class DeviceManagementServiceTest {
             "              \"access_role\": [\n" +
             "                \"team_member\"\n" +
             "              ],\n" +
-            "              \"cipher_suite\": 65535,\n" +
+            "              \"cipher_suite\": 1,\n" +
             "              \"creator\": \"99db9768-04e3-4b5d-9268-831b6a25c4ab\",\n" +
             "              \"epoch\": 18446744073709552000,\n" +
             "              \"epoch_timestamp\": \"2021-05-12T10:52:02Z\",\n" +

--- a/src/test/java/com/wire/bots/hold/utils/Constant.java
+++ b/src/test/java/com/wire/bots/hold/utils/Constant.java
@@ -1,0 +1,5 @@
+package com.wire.bots.hold.utils;
+
+public class Constant {
+    public static final Integer DEFAULT_CIPHERSUITE_IDENTIFIER = 1;
+}


### PR DESCRIPTION
#WPB-14877

* Set any ciphersuite on MLS client init, fetching it from feature config and storing it in the database
* Check for MLS being enabled in the future on non-migrated clients, enabling MLS during notification processing, storing mls support for each client in the database
* Bump to 1.2.2

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

No support for custom ciphersuites and MLS enabled only during device confirmation

### Causes (Optional)

Not being able to work in some other backends and not responsing to MLS being enabled in the future

### Solutions

Use new Xenon/Helium, setting the ciphersuite from the feature config into clients and checking for mls being supported and not already configured when processing notifications

#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
