### PR TITLE
feat(adjust-handling-mls-public-keys-from-ciphersuite) #WPB-16405

### DIFF
--- a/hold.yaml
+++ b/hold.yaml
@@ -52,7 +52,7 @@ jerseyClient:
 
 sleep: ${DELAY:-60s}
 token: ${SERVICE_TOKEN:-dummy}
-apiHost: "https://nginz-https.anta.wire.link/" # ${WIRE_API_HOST:-https://prod-nginz-https.wire.com}
+apiHost: ${WIRE_API_HOST:-https://prod-nginz-https.wire.com}
 coreCryptoPassword: ${CORE_CRYPTO_PASSWORD}
 
 database:

--- a/hold.yaml
+++ b/hold.yaml
@@ -52,7 +52,7 @@ jerseyClient:
 
 sleep: ${DELAY:-60s}
 token: ${SERVICE_TOKEN:-dummy}
-apiHost: ${WIRE_API_HOST:-https://prod-nginz-https.wire.com}
+apiHost: "https://nginz-https.anta.wire.link/" # ${WIRE_API_HOST:-https://prod-nginz-https.wire.com}
 coreCryptoPassword: ${CORE_CRYPTO_PASSWORD}
 
 database:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wire.bots</groupId>
     <artifactId>hold</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
 
     <name>Legal Hold</name>
     <description>Legal Hold Service For Wire</description>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.wire</groupId>
             <artifactId>helium</artifactId>
-            <version>1.6.1</version>
+            <version>1.6.2</version>
         </dependency>
         <dependency>
             <groupId>com.github.smoketurner</groupId>

--- a/src/test/java/com/wire/bots/hold/service/DeviceManagementServiceTest.java
+++ b/src/test/java/com/wire/bots/hold/service/DeviceManagementServiceTest.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.UUID;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.wire.bots.hold.utils.Constant.CUSTOM_CIPHERSUITE_IDENTIFIER;
 import static com.wire.bots.hold.utils.Constant.DEFAULT_CIPHERSUITE_IDENTIFIER;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.*;
@@ -510,6 +511,62 @@ public class DeviceManagementServiceTest {
     }
 
     @Test
+    public void givenEnabledMls_whenConfirmingDevice_thenCorrectCipherSuiteIsSet() throws IOException {
+        // given
+        QualifiedId conversationId = new QualifiedId(UUID.randomUUID(), MetadataDAO.FALLBACK_DOMAIN_KEY);
+
+        stubFor(get(urlEqualTo("/v6/feature-configs"))
+            .willReturn(okJson(enabledCustomMlsFeatureConfigJsonResponse)));
+        stubFor(post(urlEqualTo("/v6/access?client_id=" + clientId))
+            .willReturn(okJson(accessResponse)));
+        stubFor(get(urlEqualTo("/v6/mls/public-keys"))
+            .willReturn(okJson(mlsPublicKeysSuccessResponse)));
+        stubFor(put(urlEqualTo("/v6/clients/" + clientId))
+            .willReturn(ok()));
+        stubFor(post(urlEqualTo("/v6/mls/key-packages/self/" + clientId))
+            .willReturn(created()));
+        stubFor(post(urlEqualTo("/v6/conversations/list-ids"))
+            .willReturn(okJson(getConversationsListIdsSuccessResponse(conversationId))));
+        stubFor(post(urlEqualTo("/v6/conversations/list"))
+            .willReturn(okJson(getConversationsListSuccessResponse(conversationId))));
+        // GroupInfo of a real conversation, stored in a binary test file
+        try (InputStream inputStream = new FileInputStream("src/test/resources/dummy_mls_conversation_groupinfo.bin")) {
+            byte[] groupInfo = inputStream.readAllBytes();
+            stubFor(get(urlEqualTo("/v6/conversations/" + conversationId.domain + "/" + conversationId.id.toString() + "/groupinfo"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withBody(groupInfo)));
+        }
+        stubFor(post(urlEqualTo("/v6/mls/commit-bundles"))
+            .willReturn(ok()));
+
+        when(
+            accessDAO.insert(
+                userId.id,
+                userId.domain,
+                clientId,
+                refreshToken,
+                true,
+                CUSTOM_CIPHERSUITE_IDENTIFIER
+            )
+        ).thenReturn(1);
+
+        // when
+        deviceManagementService.confirmDevice(userId, clientId, refreshToken);
+
+        // then
+        verify(accessDAO, times(1)).insert(
+            userId.id,
+            userId.domain,
+            clientId,
+            refreshToken,
+            true,
+            CUSTOM_CIPHERSUITE_IDENTIFIER
+        );
+    }
+
+    @Test
     public void givenUnknownUser_whenRemovingDevice_thenNoMlsCallsAreMade() throws IOException, CryptoException {
         // given
         when(accessDAO.get(userId.id, userId.domain)).thenReturn(null);
@@ -637,6 +694,23 @@ public class DeviceManagementServiceTest {
                   "defaultProtocol": "proteus",
                   "protocolToggleUsers": [],
                   "supportedProtocols": ["proteus"]
+                },
+                "lockStatus": "locked",
+                "status": "enabled",
+                "ttl": "unlimited"
+            }
+        }
+    """;
+
+    private static final String enabledCustomMlsFeatureConfigJsonResponse = """
+        {
+            "mls": {
+                "config": {
+                  "allowedCipherSuites": [7],
+                  "defaultCipherSuite": 7,
+                  "defaultProtocol": "mls",
+                  "protocolToggleUsers": [],
+                  "supportedProtocols": ["mls"]
                 },
                 "lockStatus": "locked",
                 "status": "enabled",

--- a/src/test/java/com/wire/bots/hold/utils/Constant.java
+++ b/src/test/java/com/wire/bots/hold/utils/Constant.java
@@ -2,4 +2,5 @@ package com.wire.bots.hold.utils;
 
 public class Constant {
     public static final Integer DEFAULT_CIPHERSUITE_IDENTIFIER = 1;
+    public static final Integer CUSTOM_CIPHERSUITE_IDENTIFIER = 7;
 }


### PR DESCRIPTION
* Update Helium to 1.6.2 to include changes from Xenon 1.8.2 for MLS Public Key based on received ciphersuite

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Update Helium to version 1.6.2 which uses Xenon version 1.8.2 that contains the changes for handling MLS Public Keys using received ciphersuite
- Add tests
